### PR TITLE
Fix corrupted tail truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Disk Queue for Log Replay in Erlang
 
 ## Features
 
-* Queue items are written to segment files on disk to servive restart.
+* Queue items are written to segment files on disk to survive restart.
 * Batch poping items out of queue with size/count limit.
 * An `ack/2` API is provided to record the reader position within a segment.
 * Add config option `max_total_bytes` to limit the total size of replayq logs


### PR DESCRIPTION
fixes #2 

This PR upgrades replayq's internal on-disk layout to version-1
The issue with version-0 is that it allows zero-bytes items to be appended,
this may result in false data integrity when it's actually corrupted,
the chance for it to happen is pretty high: 5 consecutive zeros in the byte stream.

In this PR, for version-0 (if happen to exist before upgrade), zero-byte item is considered corruption hence truncated.
For version-1, 4 magic bytes were added to work together with CRC32 to lower the chance of false integrity.
