### PR TITLE
feat(replayq): Add offload mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ Q1 = replayq:append(Q0, [{<<"k1">>, <<"v1">>}, {<<"k2">>, <<"v2">>}]),
 {Q2, AckRef, [{<<"k1">>, <<"v1">>}]} = replayq:pop(Q1, #{count_limit => 1}),
 ok = replayq:ack(Q2, AckRef).
 ```
+
+### Offload mode
+
+In offload mode, the disk queue is only used to offload queue tail segments.
+Add `offload => true` to `Config` for `replayq:open/1`.

--- a/src/replayq.appup.src
+++ b/src/replayq.appup.src
@@ -1,0 +1,5 @@
+%% -*-: erlang -*-
+{<<".*+">>,
+  [ {<<".*+">>, [ {load_module, replayq} ]} ],
+  [ {<<".*+">>, [ {load_module, replayq} ]} ]
+}.

--- a/src/replayq.erl
+++ b/src/replayq.erl
@@ -25,7 +25,9 @@
                     seg_bytes => bytes(),
                     mem_only => boolean(),
                     max_total_bytes => bytes(),
-                    offload => boolean()
+                    offload => boolean(),
+                    sizer => sizer(),
+                    marshaller => marshaller()
                    }.
 %% writer cursor
 -define(NO_FD, no_fd).


### PR DESCRIPTION
Prior to this feature, replayq only supports two modes:
1. mem_only, which is essentially a queue:queue()
2. disk_copy, which ensures all messages are written on disk

In this commit, a new mode named 'offload' is added.
In offload mode, file is only used to offload RAM, but not to prevent
data loss from restarts.