### PR TITLE
refactor(replayq): Ensure brutal_purge safety

### DIFF
--- a/src/replayq.appup.src
+++ b/src/replayq.appup.src
@@ -1,5 +1,5 @@
 %% -*-: erlang -*-
 {<<".*+">>,
-  [ {<<".*+">>, [ {load_module, replayq} ]} ],
-  [ {<<".*+">>, [ {load_module, replayq} ]} ]
+  [ {<<".*+">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ],
+  [ {<<".*+">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ]
 }.


### PR DESCRIPTION
This commit replaces all long-lived anonymous functions with M:F/A
calls. So that duing upgrade, the old beam can be purged as soon as new
beam is loaded. i.e. brutal_purge should not cause process kill.