### PR TITLE
fix(replayq): Removed silent dequeue

### DIFF
--- a/src/replayq.app.src
+++ b/src/replayq.app.src
@@ -1,6 +1,6 @@
 {application, replayq,
  [{description, "A Disk Queue for Log Replay in Erlang"},
-  {vsn, "git"},
+  {vsn, "0.3.1"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/replayq.appup.src
+++ b/src/replayq.appup.src
@@ -1,5 +1,5 @@
 %% -*-: erlang -*-
-{<<".*+">>,
-  [ {<<".*+">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ],
-  [ {<<".*+">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ]
+{"0.3.1",
+  [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ],
+  [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ]
 }.

--- a/test/replayq_tests.erl
+++ b/test/replayq_tests.erl
@@ -176,9 +176,11 @@ append_max_total_bytes_disk_test() ->
 
 test_append_max_total_bytes(Config) ->
   Q0 = replayq:open(Config),
+  ?assertEqual(-10, replayq:overflow(Q0)),
   Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>, <<"item3">>, <<"item4">>]),
-  {Q2, _AckRef, Items} = replayq:pop(Q1, #{count_limit => 1}),
-  ?assertEqual([<<"item3">>], Items),
+  ?assertEqual(10, replayq:overflow(Q1)),
+  {Q2, _AckRef, _Items} = replayq:pop(Q1, #{count_limit => 2}),
+  ?assertEqual(0, replayq:overflow(Q2)),
   ok = replayq:close(Q2).
 
 pop_limit_disk_test() ->


### PR DESCRIPTION
Instead, expose an API for user to check if the queue is currently
overflow. Then the caller should be able to dequeue and bookkeeping
the dequeued items.