### PR TITLE
fix(replayq): async commits can be compacted

### DIFF
--- a/src/replayq.app.src
+++ b/src/replayq.app.src
@@ -1,6 +1,6 @@
 {application, replayq,
  [{description, "A Disk Queue for Log Replay in Erlang"},
-  {vsn, "0.3.1"},
+  {vsn, "0.3.2"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/replayq.appup.src
+++ b/src/replayq.appup.src
@@ -1,5 +1,5 @@
 %% -*-: erlang -*-
-{"0.3.1",
+{"0.3.2",
   [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ],
   [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ]
 }.

--- a/test/replayq_tests.erl
+++ b/test/replayq_tests.erl
@@ -108,7 +108,7 @@ test_append_pop_disk(#{dir := Dir} = Config) ->
                                             bytes_limit => 1000}),
   ?assertEqual(AckRef, AckRef1),
   ?assertEqual(Items, Items1),
-  ok = replayq:ack(Q5, AckRef),
+  lists:foreach(fun(_) -> ok = replayq:ack(Q5, AckRef) end, lists:seq(1, 100)),
   ok = replayq:close(Q5),
   Q6 = replayq:open(Config),
   ?assert(replayq:is_empty(Q6)),


### PR DESCRIPTION
Commit is a fairly slow operation as it involves creating a file
and rename. In case of async commit, the sent ack message can
be dropped if there is another one delivered to the process mailbox
already.