### PR TITLE
Skip over corrupted segments

### DIFF
--- a/src/replayq.app.src
+++ b/src/replayq.app.src
@@ -1,6 +1,6 @@
 {application, replayq,
  [{description, "A Disk Queue for Log Replay in Erlang"},
-  {vsn, "0.3.4"},
+  {vsn, "0.3.5"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/replayq.appup.src
+++ b/src/replayq.appup.src
@@ -1,5 +1,5 @@
 %% -*-: erlang -*-
-{"0.3.4",
+{"0.3.5",
   [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ],
   [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ]
 }.


### PR DESCRIPTION
Since we always write at least one element per segment file,
so the code was written in a defensive way: never expect an
empty segment.

However, we also truncate corrupted file tails,
if the very first element is corrupted,
then it is effectively an empty segment, which fails the non-empty assertion.

The fix is straightforward: skip over the corrupted segments.