### PR TITLE
feat: add optional stop before function to replayq:pop/2 options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Disk Queue for Log Replay in Erlang
 
 ### Mem Only
 
-```
+```erlang
 Q0 = replayq:open(#{mem_only => true}),
 Q1 = replayq:append(Q0, [Binary1, Binary2]),
 {Q2, AckRef, [Binary1]} = replayq:pop(Q1, #{bytes_limt => 1}),
@@ -22,7 +22,7 @@ ok = replayq:ack(Q2, AckRef).
 
 ### Binary Queue Items
 
-```
+```erlang
 Q0 = replayq:open(#{dir => "/tmp/replayq-test", seg_bytes => 10000000}),
 Q1 = replayq:append(Q0, [Binary1, Binary2]),
 {Q2, AckRef, [Binary1]} = replayq:pop(Q1, #{count_limit => 1}),
@@ -31,7 +31,7 @@ ok = replayq:ack(Q2, AckRef).
 
 ### User Defined Queue Items
 
-```
+```erlang
 Q0 = replayq:open(#{dir => "/tmp/replayq-test",
                     seg_bytes => 10000000,
                     sizer => fun({K, V}) -> size(K) + size(V) end,
@@ -42,6 +42,53 @@ Q0 = replayq:open(#{dir => "/tmp/replayq-test",
 Q1 = replayq:append(Q0, [{<<"k1">>, <<"v1">>}, {<<"k2">>, <<"v2">>}]),
 {Q2, AckRef, [{<<"k1">>, <<"v1">>}]} = replayq:pop(Q1, #{count_limit => 1}),
 ok = replayq:ack(Q2, AckRef).
+```
+
+### User Defined Stop Before Function
+
+In this example, we want to create a batch of items such that all items in the
+batch are the same. We stop adding items to the batch as soon as we encounter
+an item that differs from the first item in the batch.
+
+```erlang
+Q0 = replayq:open(#{mem_only => true}),
+Q1 = replayq:append(Q0,
+                    [
+                     <<"type1">>,
+                     <<"type1">>,
+                     <<"type2">>,
+                     <<"type2">>,
+                     <<"type2">>,
+                     <<"type3">>
+                    ]),
+StopBeforeFunc =
+fun(Item, #{current_type := none}) ->
+        #{current_type => Item};
+   (Item, #{current_type := Item}) ->
+        %% Item and current_type are the same
+        #{current_type => Item};
+   (Item, #{current_type := _OtherType}) ->
+        %% Return true to stop collecting items before the current item
+        true
+end,
+StopBeforeInitialState = #{current_type => none},
+StopBefore = {StopBeforeFunc, StopBeforeInitialState},
+%% We will stop because the stop_before function returns true
+{Q2, AckRef1, [<<"type1">>, <<"type1">>]} =
+    replayq:pop(Q1, #{stop_before => StopBefore, count_limit => 10}),
+ok = replayq:ack(Q2, AckRef1),
+%% We will stop because of the count_limit
+{Q3, AckRef2, [<<"type2">>]} =
+    replayq:pop(Q2, #{stop_before => StopBefore, count_limit => 1}),
+ok = replayq:ack(Q3, AckRef2),
+%% We will stop because the stop_before function returns true
+{Q4, AckRef3, [<<"type2">>, <<"type2">>]} =
+    replayq:pop(Q3, #{stop_before => StopBefore, count_limit => 10}),
+ok = replayq:ack(Q4, AckRef3),
+%% We will stop because the queue gets empty
+{Q5, AckRef4, [<<"type3">>]} =
+    replayq:pop(Q4, #{stop_before => StopBefore, count_limit => 10}),
+ok = replayq:ack(Q5, AckRef4).
 ```
 
 ### Offload mode

--- a/src/replayq.appup.src
+++ b/src/replayq.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"0.3.7",
+{"0.3.8",
   [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ],
   [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ]
 }.

--- a/src/replayq.erl
+++ b/src/replayq.erl
@@ -7,7 +7,10 @@
 -export([do_read_items/2]).
 
 %% internal exports for beam reload
--export([committer_loop/2, default_sizer/1, default_marshaller/1]).
+-export([committer_loop/2,
+         default_sizer/1,
+         default_marshaller/1,
+         default_stop_before_func/2]).
 
 -export_type([config/0, q/0, ack_ref/0, sizer/0, marshaller/0]).
 
@@ -241,7 +244,7 @@ pop(Q, Opts) ->
   Bytes = maps:get(bytes_limit, Opts, ?DEFAULT_POP_BYTES_LIMIT),
   Count = maps:get(count_limit, Opts, ?DEFAULT_POP_COUNT_LIMIT),
   {StopFun, StopFunAcc} =
-    maps:get(stop_before, Opts, {fun default_stop_before_func/2, none}),
+    maps:get(stop_before, Opts, {fun ?MODULE:default_stop_before_func/2, none}),
   true = (Count > 0),
   pop(Q, Bytes, Count, ?NOTHING_TO_ACK, [], StopFun, StopFunAcc).
 

--- a/src/replayq.erl
+++ b/src/replayq.erl
@@ -24,6 +24,8 @@
 -type ack_ref() :: ?NOTHING_TO_ACK | {segno(), ID :: pos_integer()}.
 -type sizer() :: fun((item()) -> bytes()).
 -type marshaller() :: fun((item()) -> binary()).
+-type accumulator() :: term().
+-type stop_function() :: fun((item(), accumulator()) -> true | accumulator()).
 
 -type config() :: #{dir => dir(),
                     seg_bytes => bytes(),
@@ -226,13 +228,21 @@ append(#{config := #{seg_bytes := BytesLimit, dir := Dir} = Config,
 
 %% @doc pop out at least one item from the queue.
 %% volume limited by `bytes_limit' and `count_limit'.
--spec pop(q(), #{bytes_limit => bytes(), count_limit => count()}) ->
+-spec pop(q(),
+          #{
+            bytes_limit => bytes(),
+            count_limit => count(),
+            stop_before => stop_function(),
+            stop_before_input_accumulator => term()
+           }) ->
         {q(), ack_ref(), [item()]}.
 pop(Q, Opts) ->
   Bytes = maps:get(bytes_limit, Opts, ?DEFAULT_POP_BYTES_LIMIT),
   Count = maps:get(count_limit, Opts, ?DEFAULT_POP_COUNT_LIMIT),
+  StopFun = maps:get(stop_before, Opts, fun default_stop_function/2),
+  StopFunAcc = maps:get(stop_before_input_accumulator, Opts, #{}),
   true = (Count > 0),
-  pop(Q, Bytes, Count, ?NOTHING_TO_ACK, []).
+  pop(Q, Bytes, Count, ?NOTHING_TO_ACK, [], StopFun, StopFunAcc).
 
 %% @doc peek the queue front item.
 -spec peek(q()) -> empty | item().
@@ -290,6 +300,9 @@ is_mem_only(_) ->
 
 %% internals =========================================================
 
+default_stop_function(_Item, Acc) ->
+  Acc.
+
 transform(Id, Items, Sizer) ->
   transform(Id, Items, Sizer, 0, 0, []).
 
@@ -307,59 +320,81 @@ transform(Id, [Item0 | Rest], Sizer, Count, Bytes, Acc) ->
 append_in_mem([], Q) -> Q;
 append_in_mem([Item | Rest], Q) -> append_in_mem(Rest, queue:in(Item, Q)).
 
-pop(Q, _Bytes, 0, AckRef, Acc) ->
+pop(Q, _Bytes, 0, AckRef, Acc, _StopFun, _StopFunAcc) ->
   Result = lists:reverse(Acc),
   ok = maybe_save_pending_acks(AckRef, Q, Result),
   {Q, AckRef, Result};
-pop(#{config := Cfg} = Q, Bytes, Count, AckRef, Acc) ->
+pop(#{config := Cfg} = Q, Bytes, Count, AckRef, Acc, StopFun, StopFunAcc) ->
   case is_empty(Q) of
     true ->
       {Q, AckRef, lists:reverse(Acc)};
     false when Cfg =:= mem_only ->
-      pop_mem(Q, Bytes, Count, Acc);
+      pop_mem(Q, Bytes, Count, Acc, StopFun, StopFunAcc);
     false ->
-      pop2(Q, Bytes, Count, AckRef, Acc)
+      pop2(Q, Bytes, Count, AckRef, Acc, StopFun, StopFunAcc)
   end.
 
 pop_mem(#{in_mem := InMem,
           stats := #{count := TotalCount, bytes := TotalBytes} = Stats
-         } = Q, Bytes, Count, Acc) ->
+         } = Q, Bytes, Count, Acc, StopFun, StopFunAcc) ->
   case queue:out(InMem) of
     {{value, ?MEM_ONLY_ITEM(Sz, _Item)}, _} when Sz > Bytes andalso Acc =/= [] ->
       {Q, ?NOTHING_TO_ACK, lists:reverse(Acc)};
     {{value, ?MEM_ONLY_ITEM(Sz, Item)}, Rest} ->
-      NewQ = Q#{in_mem := Rest,
-                stats := Stats#{count := TotalCount - 1,
-                                bytes := TotalBytes - Sz
-                               }
-               },
-      pop(NewQ, Bytes - Sz, Count - 1, ?NOTHING_TO_ACK, [Item | Acc])
+      case StopFun(Item, StopFunAcc) of
+        true ->
+          {Q, ?NOTHING_TO_ACK, lists:reverse(Acc)};
+        NewStopFunAcc ->
+          NewQ = Q#{in_mem := Rest,
+                    stats := Stats#{count := TotalCount - 1,
+                                    bytes := TotalBytes - Sz
+                                   }
+                   },
+          pop(NewQ,
+              Bytes - Sz,
+              Count - 1,
+              ?NOTHING_TO_ACK,
+              [Item | Acc],
+              StopFun,
+              NewStopFunAcc)
+      end
   end.
 
 pop2(#{head_segno := ReaderSegno,
        in_mem := HeadItems,
        stats := #{count := TotalCount, bytes := TotalBytes} = Stats
-      } = Q, Bytes, Count, AckRef, Acc) ->
+      } = Q, Bytes, Count, AckRef, Acc, StopFun, StopFunAcc) ->
   case queue:out(HeadItems) of
     {empty, _} ->
       Q1 = open_next_seg(Q),
-      pop(Q1, Bytes, Count, AckRef, Acc);
+      pop(Q1, Bytes, Count, AckRef, Acc, StopFun, StopFunAcc);
     {{value, ?DISK_CP_ITEM(_, Sz, _Item)}, _} when Sz > Bytes andalso Acc =/= [] ->
       %% taking the head item would cause exceeding size limit
       {Q, AckRef, lists:reverse(Acc)};
-    {{value, ?DISK_CP_ITEM(Id, Sz, Item)}, Rest} ->
-      Q1 = Q#{in_mem := Rest,
-              stats := Stats#{count := TotalCount - 1,
-                              bytes := TotalBytes - Sz
-                             }
-             },
-      %% read the next segment in case current is drained
-      NewQ = case queue:is_empty(Rest) of
-               true -> open_next_seg(Q1);
-               false -> Q1
-             end,
-      NewAckRef = {ReaderSegno, Id},
-      pop(NewQ, Bytes - Sz, Count - 1, NewAckRef, [Item | Acc])
+      {{value, ?DISK_CP_ITEM(Id, Sz, Item)}, Rest} ->
+        case StopFun(Item, StopFunAcc) of
+          true ->
+            {Q, AckRef, lists:reverse(Acc)};
+          NewStopFunAcc ->
+            Q1 = Q#{in_mem := Rest,
+                    stats := Stats#{count := TotalCount - 1,
+                                    bytes := TotalBytes - Sz
+                                   }
+                   },
+            %% read the next segment in case current is drained
+            NewQ = case queue:is_empty(Rest) of
+                     true -> open_next_seg(Q1);
+                     false -> Q1
+                   end,
+            NewAckRef = {ReaderSegno, Id},
+            pop(NewQ,
+                Bytes - Sz,
+                Count - 1,
+                NewAckRef,
+                [Item | Acc],
+                StopFun,
+                NewStopFunAcc)
+        end
   end.
 
 %% due to backward compatibility reasons for the ack api

--- a/test/replayq_tests.erl
+++ b/test/replayq_tests.erl
@@ -404,10 +404,24 @@ is_in_mem_test_() ->
 
 stop_before_test_() ->
   [{"mem queue",
-    fun() -> stop_before_test(#{mem_only => true}) end},
+    fun() ->
+            Config = #{mem_only => true},
+            stop_before_test(Config),
+            stop_before_readme_example_test(Config)
+    end},
    {"disk queue",
-    fun() -> stop_before_test(#{dir => ?DIR, seg_bytes => 100}) end}].
-
+    fun() ->
+            Config1 = #{
+                       dir => ?DIR,
+                       seg_bytes => 100
+                      },
+            stop_before_test(Config1),
+            Config2 = #{
+                       dir => filename:join([?DIR, "example"]),
+                       seg_bytes => 100
+                      },
+            stop_before_readme_example_test(Config2)
+    end}].
 
 stop_before_test(Config) ->
     Q0 = replayq:open(Config),
@@ -423,13 +437,54 @@ stop_before_test(Config) ->
                   #{
                     count_limit => 100,
                     bytes_limit => 10000000,
-                    stop_before => StopBeforeFun,
-                    stop_before_input_accumulator => #{stop_ctr => 0}
+                    stop_before => {StopBeforeFun, #{stop_ctr => 0}}
                    }),
     ok = replayq:ack(Q2, AckRef),
     ?assertEqual([<<"1">>, <<"2">>, <<"3">>], Items),
     ?assertEqual(2, replayq:count(Q2)),
     ok = replayq:close(Q2).
+
+%% Test that the example in the readme file works
+stop_before_readme_example_test(Config) ->
+    Q0 = replayq:open(Config),
+    Q1 = replayq:append(Q0,
+                        [
+                         <<"type1">>,
+                         <<"type1">>,
+                         <<"type2">>,
+                         <<"type2">>,
+                         <<"type2">>,
+                         <<"type3">>
+                        ]),
+    StopBeforeFunc =
+    fun(Item, #{current_type := none}) ->
+            #{current_type => Item};
+       (Item, #{current_type := Item}) ->
+            %% Item and current_type are the same
+            #{current_type => Item};
+       (_Item, #{current_type := _OtherType}) ->
+            %% Return true to stop collecting items before the current item
+            true
+    end,
+    StopBeforeInitialState = #{current_type => none},
+    StopBefore = {StopBeforeFunc, StopBeforeInitialState},
+    %% We will stop because the stop_before function returns true
+    {Q2, AckRef1, [<<"type1">>, <<"type1">>]} =
+        replayq:pop(Q1, #{stop_before => StopBefore, count_limit => 10}),
+    ok = replayq:ack(Q2, AckRef1),
+    %% We will stop because of the count_limit
+    {Q3, AckRef2, [<<"type2">>]} =
+        replayq:pop(Q2, #{stop_before => StopBefore, count_limit => 1}),
+    ok = replayq:ack(Q3, AckRef2),
+    %% We will stop because the stop_before function returns true
+    {Q4, AckRef3, [<<"type2">>, <<"type2">>]} =
+        replayq:pop(Q3, #{stop_before => StopBefore, count_limit => 10}),
+    ok = replayq:ack(Q4, AckRef3),
+    %% We will stop because the queue gets empty
+    {Q5, AckRef4, [<<"type3">>]} =
+        replayq:pop(Q4, #{stop_before => StopBefore, count_limit => 10}),
+    ok = replayq:ack(Q5, AckRef4),
+    ok = replayq:close(Q5).
 
 %% helpers ===========================================================
 


### PR DESCRIPTION
Two new optional options has been added to the replayq:pop/2 function:

* stop_before and,
* stop_before_input_accumulator.

The stop_before option is a function where the first argument is the current item, and the second argument is an accumulator (starts with the value of stop_before_input_accumulator if specified or #{} if stop_before_input_accumulator is not specified). The stop_before function should return true if the pop call should stop adding items before the current item. If the stop_before function does not return true, the returned value will be the accumulator argument to the next call of the stop_before function.