### PR TITLE
fix: avoid turning huge filepaths to atoms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,23 +3,26 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        otp: [23.2, 24.0.2]
+        otp: ['26.2.5', '27.1']
+        rebar3: ['3.22.1']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.1
         with:
           submodules: recursive
-      - uses: gleam-lang/setup-erlang@v1.1.2
+      - name: Setup Erlang/OTP
+        uses: erlef/setup-beam@v1.17.5
         with:
           otp-version: ${{ matrix.otp }}
+          rebar3-version: ${{ matrix.rebar3 }}
       - run: |
           make
       - name: Archive CT Logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.3
         with:
-          name: ct-logs
+          name: ct-logs-${{ matrix.otp }}
           path: _build/test/
           retention-days: 1

--- a/src/replayq.app.src
+++ b/src/replayq.app.src
@@ -1,12 +1,13 @@
 {application, replayq,
  [{description, "A Disk Queue for Log Replay in Erlang"},
   {vsn, "git"},
-  {registered, []},
+  {registered, [replayq_sup, replayq_registry]},
   {applications,
    [kernel,
     stdlib
    ]},
   {env,[]},
+  {mod, {replayq_app, []}},
   {modules, []},
   {licenses, ["Apache 2.0"]},
   {links, [{"GitHub", "https://github.com/emqx/replayq"}]}

--- a/src/replayq.app.src
+++ b/src/replayq.app.src
@@ -1,6 +1,6 @@
 {application, replayq,
  [{description, "A Disk Queue for Log Replay in Erlang"},
-  {vsn, "0.3.7"},
+  {vsn, "git"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/replayq.appup.src
+++ b/src/replayq.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"0.3.8",
+{VSN,
   [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ],
   [ {<<".*">>, [ {load_module, replayq, brutal_purge, soft_purge, []} ]} ]
 }.

--- a/src/replayq_app.erl
+++ b/src/replayq_app.erl
@@ -1,0 +1,18 @@
+-module(replayq_app).
+
+-behaviour(application).
+
+%% `application' API
+-export([start/2, stop/1]).
+
+%%------------------------------------------------------------------------------
+%% `application' API
+%%------------------------------------------------------------------------------
+
+-spec start(application:start_type(), term()) -> {ok, pid()}.
+start(_Type, _Args) ->
+    replayq_sup:start_link().
+
+-spec stop(term()) -> ok.
+stop(_State) ->
+    ok.

--- a/src/replayq_registry.erl
+++ b/src/replayq_registry.erl
@@ -33,7 +33,8 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-register_committer(Dir, Pid) ->
+register_committer(Dir0, Pid) ->
+    Dir = iolist_to_binary(Dir0),
     gen_server:call(?MODULE, #register_committer{dir = Dir, pid = Pid}, infinity).
 
 deregister_committer(Pid) ->

--- a/src/replayq_registry.erl
+++ b/src/replayq_registry.erl
@@ -1,0 +1,108 @@
+-module(replayq_registry).
+
+-behaviour(gen_server).
+
+%% API
+-export([
+    start_link/0,
+
+    register_committer/2,
+    deregister_committer/1
+]).
+
+%% `gen_server' API
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+%% call/cast/info events
+-record(register_committer, {dir :: filename:filename_all(), pid :: pid()}).
+-record(deregister_committer, {pid :: pid()}).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+register_committer(Dir, Pid) ->
+    gen_server:call(?MODULE, #register_committer{dir = Dir, pid = Pid}, infinity).
+
+deregister_committer(Pid) ->
+    gen_server:call(?MODULE, #deregister_committer{pid = Pid}, infinity).
+
+%%------------------------------------------------------------------------------
+%% `gen_server' API
+%%------------------------------------------------------------------------------
+
+init(_Opts) ->
+    process_flag(trap_exit, true),
+    State = #{committers => #{}},
+    {ok, State}.
+
+handle_call(#register_committer{dir = Dir, pid = Pid}, _From, State0) ->
+    %% Should we expand the directory path to avoid tricks with links and relative paths?
+    #{committers := Committers0} = State0,
+    case Committers0 of
+        #{Dir := SomePid} ->
+            case is_process_alive(SomePid) of
+                true ->
+                    {reply, {error, already_registered}, State0};
+                false ->
+                    {_, State1} = pop_committer(State0, SomePid),
+                    State = do_register_committer(State1, Dir, Pid),
+                    {reply, ok, State}
+            end;
+        _ ->
+            State = do_register_committer(State0, Dir, Pid),
+            {reply, ok, State}
+    end;
+handle_call(#deregister_committer{pid = Pid}, _From, #{committers := Committers0} = State0) ->
+    case is_map_key(Pid, Committers0) of
+        false ->
+            {reply, ok, State0};
+        true ->
+            {_, State} = pop_committer(State0, Pid),
+            {reply, ok, State}
+    end;
+handle_call(_Call, _From, State) ->
+    {reply, {error, unknown_call}, State}.
+
+handle_cast(_Cast, State) ->
+    {noreply, State}.
+
+handle_info({'EXIT', Pid, _Reason}, #{committers := Committers0} = State0) when
+      is_map_key(Pid, Committers0)
+->
+    {_, State} = pop_committer(State0, Pid),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+add_committer(Committers, Pid, Dir) ->
+    Committers#{Pid => Dir, Dir => Pid}.
+
+pop_committer(State0, Pid) ->
+    #{committers := Committers0} = State0,
+    {Dir, Committers1} = maps:take(Pid, Committers0),
+    {Pid, Committers} = maps:take(Dir, Committers1),
+    State = State0#{committers := Committers},
+    {{Pid, Dir}, State}.
+
+do_register_committer(State0, Dir, Pid) ->
+    #{committers := Committers0} = State0,
+    link(Pid),
+    Committers = add_committer(Committers0, Pid, Dir),
+    State0#{committers := Committers}.

--- a/src/replayq_sup.erl
+++ b/src/replayq_sup.erl
@@ -1,0 +1,43 @@
+-module(replayq_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% `supervisor' API
+-export([init/1]).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%%------------------------------------------------------------------------------
+%% `supervisor' API
+%%------------------------------------------------------------------------------
+
+init([]) ->
+    Registry = worker_spec(replayq_registry),
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 10
+    },
+    ChildSpecs = [Registry],
+    {ok, {SupFlags, ChildSpecs}}.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+worker_spec(Mod) ->
+    #{
+        id => Mod,
+        start => {Mod, start_link, []},
+        restart => permanent,
+        shutdown => 5_000,
+        type => worker
+    }.

--- a/test/replayq_tests.erl
+++ b/test/replayq_tests.erl
@@ -7,6 +7,7 @@
 
 %% the very first run
 init_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir, seg_bytes => 100},
   Q1 = replayq:open(Config),
@@ -20,6 +21,7 @@ init_test() ->
   ok = cleanup(Dir).
 
 reopen_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir, seg_bytes => 100},
   Q0 = replayq:open(Config),
@@ -47,6 +49,7 @@ volatile_test() ->
 %% when popping from in-mem segment, the segment size stats may overflow
 %% but not consuming as much memory
 offload_in_mem_seg_overflow_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir, seg_bytes => 11, offload => true},
   Q0 = replayq:open(Config),
@@ -62,6 +65,7 @@ offload_in_mem_seg_overflow_test() ->
   ok = cleanup(Dir).
 
 offload_file_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir, seg_bytes => 10, offload => true},
   Q0 = replayq:open(Config),
@@ -89,6 +93,7 @@ offload_file_test() ->
   ok = cleanup(Dir).
 
 offload_reopen_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir, seg_bytes => 100, offload => true},
   Q0 = replayq:open(Config),
@@ -128,11 +133,13 @@ reopen_v0_test() ->
   ok = cleanup(Dir).
 
 append_pop_disk_default_marshaller_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir, seg_bytes => 1},
   test_append_pop_disk(Config).
 
 append_pop_disk_my_marshaller_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir,
              seg_bytes => 1,
@@ -144,6 +151,7 @@ append_pop_disk_my_marshaller_test() ->
   test_append_pop_disk(Config).
 
 test_append_pop_disk(#{dir := Dir} = Config) ->
+  {ok, _} = application:ensure_all_started(replayq),
   Q0 = replayq:open(Config),
   Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>]),
   Q2 = replayq:append(Q1, [<<"item3">>]),
@@ -170,10 +178,12 @@ test_append_pop_disk(#{dir := Dir} = Config) ->
   ok = cleanup(Dir).
 
 append_pop_mem_default_marshaller_test_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Config = #{mem_only => true},
   test_append_pop_mem(Config).
 
 append_pop_mem_my_marshaller_test_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Config = #{mem_only => true,
              sizer => fun(Item) -> size(Item) end,
              marshaller => fun(<<"mmp", I/binary>>) -> I;
@@ -202,6 +212,7 @@ test_append_pop_mem(Config) ->
   ok = replayq:close(Q5).
 
 append_max_total_bytes_mem_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Config = #{mem_only => true,
              sizer => fun(Item) -> size(Item) end,
              marshaller => fun(<<"mmp", I/binary>>) -> I;
@@ -213,6 +224,7 @@ append_max_total_bytes_mem_test() ->
   ok.
 
 append_max_total_bytes_disk_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir,
              seg_bytes => 1,
@@ -226,6 +238,7 @@ append_max_total_bytes_disk_test() ->
   ok = cleanup(Dir).
 
 test_append_max_total_bytes(Config) ->
+  {ok, _} = application:ensure_all_started(replayq),
   Q0 = replayq:open(Config),
   ?assertEqual(-10, replayq:overflow(Q0)),
   Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>, <<"item3">>, <<"item4">>]),
@@ -235,12 +248,14 @@ test_append_max_total_bytes(Config) ->
   ok = replayq:close(Q2).
 
 pop_limit_disk_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir, seg_bytes => 1},
   ok = test_pop_limit(Config),
   ok = cleanup(Dir).
 
 pop_limit_mem_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Config = #{mem_only => true},
   ok = test_pop_limit(Config).
 
@@ -257,6 +272,7 @@ test_pop_limit(Config) ->
   ok = replayq:close(Q4).
 
 commit_in_the_middle_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   Config = #{dir => Dir, seg_bytes => 1000},
   Q0 = replayq:open(Config),
@@ -279,6 +295,7 @@ commit_in_the_middle_test() ->
   ok = cleanup(Dir).
 
 first_segment_corrupted_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   SegBytes = 10,
   Config = #{dir => Dir, seg_bytes => SegBytes},
@@ -300,6 +317,7 @@ first_segment_corrupted_test() ->
   ok = cleanup(Dir).
 
 second_segment_corrupted_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   SegBytes = 10,
   Config = #{dir => Dir, seg_bytes => SegBytes},
@@ -322,6 +340,7 @@ second_segment_corrupted_test() ->
   ok = cleanup(Dir).
 
 last_segment_corrupted_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
   SegBytes = 10,
   Config = #{dir => Dir, seg_bytes => SegBytes},
@@ -351,6 +370,7 @@ last_segment_corrupted_test() ->
   ok = cleanup(Dir).
 
 corrupted_segment_test_() ->
+  {ok, _} = application:ensure_all_started(replayq),
   [{"ramdom", fun() -> test_corrupted_segment(<<"foo">>) end},
    {"v0-bad-crc", fun() -> test_corrupted_segment(<<0:8, 0:32, 1:32, 1:8>>) end},
    {"v0-zero-crc", fun() -> test_corrupted_segment(<<0:8, 0:32, 0:32, "randomtail">>) end},
@@ -377,12 +397,12 @@ test_corrupted_segment(BadBytes) ->
   ok = cleanup(Dir).
 
 comitter_crash_test() ->
+  {ok, _} = application:ensure_all_started(replayq),
   Dir = ?DIR,
-  ComitterName = replayq:committer_process_name(Dir),
   Config = #{dir => Dir, seg_bytes => 1000},
-  _ = replayq:open(Config),
+  #{committer := Committer} = replayq:open(Config),
   erlang:process_flag(trap_exit, true),
-  ComitterName ! <<"foo">>,
+  Committer ! <<"foo">>,
   receive
     {'EXIT', _Pid, {replayq_committer_unkown_msg, <<"foo">>}} ->
       ok
@@ -391,15 +411,32 @@ comitter_crash_test() ->
 %% Checks that our spawned committer can register a name for itself when using filepaths
 %% larger than 255 bytes.
 huge_filepath_test() ->
+    {ok, _} = application:ensure_all_started(replayq),
     Dir0 = ?DIR,
     Dir = filename:join(Dir0, binary:copy(<<"a">>, 255)),
     Config = #{dir => Dir, seg_bytes => 1000},
-    _ = replayq:open(Config),
-    CommitterName = replayq:committer_process_name(Dir),
-    ?assert(is_process_alive(whereis(CommitterName))),
+    Q = #{committer := Committer} = replayq:open(Config),
+    ?assert(is_process_alive(Committer)),
+    replayq:close(Q),
+    ok.
+
+%% Checks that we don't allow having the same directory open by multiple replayqs.
+same_directory_committer_clash_test() ->
+    {ok, _} = application:ensure_all_started(replayq),
+    Dir = ?DIR,
+    Config = #{dir => Dir, seg_bytes => 1000},
+    Q1 = replayq:open(Config),
+    try replayq:open(Config) of
+        Q2 -> error({"should not allow opening a second replayq", Q2})
+    catch
+        error:{badmatch, {error, already_registered}} ->
+            ok
+    end,
+    replayq:close(Q1),
     ok.
 
 is_in_mem_test_() ->
+  {ok, _} = application:ensure_all_started(replayq),
   [ {"mem queue", fun() ->
                       Q = replayq:open(#{mem_only => true}),
                       true = replayq:is_mem_only(Q),
@@ -414,6 +451,7 @@ is_in_mem_test_() ->
   ].
 
 stop_before_test_() ->
+  {ok, _} = application:ensure_all_started(replayq),
   [{"mem queue",
     fun() ->
             Config = #{mem_only => true},
@@ -435,6 +473,7 @@ stop_before_test_() ->
     end}].
 
 stop_before_test(Config) ->
+  {ok, _} = application:ensure_all_started(replayq),
     Q0 = replayq:open(Config),
     Q1 = replayq:append(Q0, [<<"1">>, <<"2">>, <<"3">>, <<"4">>, <<"5">>]),
     StopBeforeFun =
@@ -457,6 +496,7 @@ stop_before_test(Config) ->
 
 %% Test that the example in the readme file works
 stop_before_readme_example_test(Config) ->
+    {ok, _} = application:ensure_all_started(replayq),
     Q0 = replayq:open(Config),
     Q1 = replayq:append(Q0,
                         [


### PR DESCRIPTION
Specially when running with CT, used filepaths may become larger than the maximum atom
size of 255 bytes:

```
2024-10-17T14:18:10.117220+00:00 [error] GenServer #PID<0.31263.0> terminating, ** (SystemLimitError) a system limit has been reached, :erlang.binary_to_atom("/emqx/_build/emqx-enterprise-test/logs/ct_run.test@127.0.0.1.2024-10-17_14.18.07/apps.emqx_bridge_kafka.emqx_bridge_v2_kafka_producer_SUITE.t_fixed_topic_recovers_in_disk_mode.logs/run.2024-10-17_14.18.07/log_private/emqx_bridge_v2_kafka_producer_SUITE_data/kafka/kafka:fixed_topic_disk_recover:test@127.0.0.1/action=3akafka_producer=3afixed_topic_disk_recover=3aconnector=3akafka_producer=3ac_test-topic-one-partition/0/committer", :utf8), (replayq 0.3.7) /emqx/deps/replayq/src/replayq.erl:520: :replayq.spawn_committer/2, (replayq 0.3.7) /emqx/deps/replayq/src/replayq.erl:103: :replayq.open/1, (wolff 4.0.2) /emqx/deps/wolff/src/wolff_producer.erl:258: :wolff_producer.do_init/1, (wolff 4.0.2) /emqx/deps/wolff/src/wolff_producer.erl:298: :wolff_producer.handle_info/2, (stdlib 5.2.3.1) gen_server.erl:1095: :gen_server.try_handle_info/3, (stdlib 5.2.3.1) gen_server.erl:1183: :gen_server.handle_msg/6, (stdlib 5.2.3.1) proc_lib.erl:241: :proc_lib.init_p_do_apply/3, Last message: {:do_init, %{config: %{group: "action:kafka_producer:fixed_topic_disk_recover:connector:kafka_producer:c", max_linger_bytes: 10485760, max_batch_bytes: 917504, required_acks: :all_isr, compression: :no_compression, replayq_dir: "/emqx/_build/emqx-enterprise-test/logs/ct_run.test@127.0.0.1.2024-10-17_14.18.07/apps.emqx_bridge_kafka.emqx_bridge_v2_kafka_producer_SUITE.t_fixed_topic_recovers_in_disk_mode.logs/run.2024-10-17_14.18.07/log_private/emqx_bridge_v2_kafka_producer_SUITE_data/kafka/kafka:fixed_topic_disk_recover:test@127.0.0.1", replayq_offload_mode: false, replayq_max_total_bytes: 2147483648, replayq_seg_bytes: 104857600, drop_if_highmem: false, ack_timeout: 10000, partitioner: :random, partition_count_refresh_interval_seconds: 60, max_linger_ms: 0, max_send_ahead: 9, telemetry_meta_data: %{bridge_id: "action:kafka_producer:fixed_topic_disk_recover:connector:kafka_producer:c"}, max_partitions: :all_partitions, reconnect_delay_ms: 2000}, partition: 0, topic: "test-topic-one-partition", client_id: "connector:kafka_producer:c", conn: #PID<0.31253.0>, linger_expire_timer: false}}
```
