### PR TITLE
fix: tolerate corrupted COMMIT file

### DIFF
--- a/test/replayq_tests.erl
+++ b/test/replayq_tests.erl
@@ -537,6 +537,28 @@ stop_before_readme_example_test(Config) ->
     ok = replayq:ack(Q5, AckRef4),
     ok = replayq:close(Q5).
 
+corrupted_commit_test() ->
+  Dir = ?DIR,
+  Config = #{dir => Dir, seg_bytes => 1000},
+  Q0 = replayq:open(Config),
+  Q1 = replayq:append(Q0, [<<"item1">>]),
+  {Q2, AckRef, _} = replayq:pop(Q1, #{count_limit => 3}),
+  ok = replayq:ack_sync(Q2, AckRef),
+  ok = replayq:close(Q2),
+  CommitFile = filename:join(Dir, "COMMIT"),
+  ?assertMatch({ok, [_]}, file:consult(CommitFile)),
+
+  ok = file:write_file(CommitFile, <<>>),
+  %% assert no crash
+  Q3 = replayq:open(Config),
+  ok = replayq:close(Q3),
+
+  ok = file:write_file(CommitFile, <<"bad-erlang-term">>),
+  %% assert no crash
+  Q4 = replayq:open(Config),
+  ok = replayq:close(Q4),
+  ok = cleanup(Dir).
+
 %% helpers ===========================================================
 
 cleanup(Dir) ->


### PR DESCRIPTION
Observed COMMIT file corruption in a system which got IOPS limited.

The file is updated as follows

1. write content to `COMMIT.tmp`
2. rename `COMMIT.tmp` to `COMMIT`.

Due to unknown reason, `COMMIT` file can end up with empty content.

This PR ignores empty `COMMIT` file, also made the code to tolerate corrupted content.