### PR TITLE
Add in-memory queue/segment implementation on ETS

### DIFF
--- a/src/replayq_mem.erl
+++ b/src/replayq_mem.erl
@@ -19,15 +19,14 @@
 
 -export([
     new/2,
-    from_list/3,
-    to_list/2,
+    peek_all/2,
     peek/2,
     is_empty/2,
     in/3,
     in_r/3,
     in_batch/3,
     out/2,
-    purge/2
+    destroy/2
 ]).
 
 -export_type([options/0, queue/1]).
@@ -37,29 +36,23 @@
 -type queue(_Term) :: term().
 
 -callback new(options()) -> queue(_).
--callback to_list(queue(_)) -> [term()].
+-callback peek_all(queue(_)) -> [term()].
 -callback peek(queue(_)) -> empty | {value, term()}.
 -callback is_empty(queue(_)) -> boolean().
 -callback in(term(), queue(_)) -> queue(_).
 -callback in_batch([term()], queue(_)) -> queue(_).
 -callback out(queue(_)) -> {empty, queue(_)} | {{value, term()}, queue(_)}.
--callback purge(queue(_)) -> ok.
+-callback destroy(queue(_)) -> ok.
 
 %% @doc Create a new queue.
 -spec new(module(), options()) -> queue(_).
 new(Module, Options) ->
     Module:new(Options).
 
-%% @doc Create a new queue from a list.
--spec from_list(module(), options(), [term()]) -> queue(_).
-from_list(Module, Options, List) ->
-    Q = Module:new(Options),
-    in_batch(Module, List, Q).
-
-%% @doc Convert a queue to a list.
--spec to_list(module(), queue(_)) -> [term()].
-to_list(Module, Q) ->
-    Module:to_list(Q).
+%% @doc Peek all items from the queue.
+-spec peek_all(module(), queue(_)) -> [term()].
+peek_all(Module, Q) ->
+    Module:peek_all(Q).
 
 %% @doc Peek at the next item in the queue.
 -spec peek(module(), queue(_)) -> empty | {value, term()}.
@@ -91,10 +84,10 @@ in_batch(Module, Items, Q) ->
 out(Module, Q) ->
     Module:out(Q).
 
-%% @doc Purge the queue.
--spec purge(module(), queue(_)) -> ok.
-purge(Module, Q) ->
-    Module:purge(Q).
+%% @doc Destroy the queue.
+-spec destroy(module(), queue(_)) -> ok.
+destroy(Module, Q) ->
+    Module:destroy(Q).
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/src/replayq_mem.erl
+++ b/src/replayq_mem.erl
@@ -70,6 +70,8 @@ in(Module, Item, Q) ->
     Module:in(Item, Q).
 
 %% @doc Insert an item into the queue in reverse order.
+%% This is only intended for returning items to the queue after out/2.
+%% But not for normal inverse order enqueue.
 -spec in_r(module(), term(), queue(_)) -> queue(_).
 in_r(Module, Item, Q) ->
     Module:in_r(Item, Q).

--- a/src/replayq_mem.erl
+++ b/src/replayq_mem.erl
@@ -26,7 +26,8 @@
     in/3,
     in_r/3,
     in_batch/3,
-    out/2
+    out/2,
+    purge/2
 ]).
 
 -export_type([options/0, queue/1]).
@@ -42,6 +43,7 @@
 -callback in(term(), queue(_)) -> queue(_).
 -callback in_batch([term()], queue(_)) -> queue(_).
 -callback out(queue(_)) -> {empty, queue(_)} | {{value, term()}, queue(_)}.
+-callback purge(queue(_)) -> ok.
 
 %% @doc Create a new queue.
 -spec new(module(), options()) -> queue(_).
@@ -52,7 +54,7 @@ new(Module, Options) ->
 -spec from_list(module(), options(), [term()]) -> queue(_).
 from_list(Module, Options, List) ->
     Q = Module:new(Options),
-    Module:in_batch(List, Q).
+    in_batch(Module, List, Q).
 
 %% @doc Convert a queue to a list.
 -spec to_list(module(), queue(_)) -> [term()].
@@ -88,3 +90,14 @@ in_batch(Module, Items, Q) ->
 -spec out(module(), queue(_)) -> {empty, queue(_)} | {{value, term()}, queue(_)}.
 out(Module, Q) ->
     Module:out(Q).
+
+%% @doc Purge the queue.
+-spec purge(module(), queue(_)) -> ok.
+purge(Module, Q) ->
+    Module:purge(Q).
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/src/replayq_mem_ets_exclusive.erl
+++ b/src/replayq_mem_ets_exclusive.erl
@@ -33,7 +33,8 @@
 
 -export_type([queue/0]).
 
--opaque queue() :: #{ets_tab := ets:tab(), next_id := non_neg_integer()}.
+-type id() :: integer().
+-opaque queue() :: #{ets_tab := ets:tab(), next_id := id()}.
 
 %% @doc Create a new queue.
 -spec new(_) -> queue().
@@ -75,9 +76,6 @@ in_r(Item, #{ets_tab := Tab} = Q) ->
         '$end_of_table' ->
             in(Item, Q);
         Id ->
-            %% Id is the key of the first item in the queue
-            %% do not allow inverse order enqueue
-            Id =< 1 andalso erlang:error(badarg),
             ets:insert(Tab, {Id - 1, Item}),
             Q
     end.

--- a/src/replayq_mem_ets_exclusive.erl
+++ b/src/replayq_mem_ets_exclusive.erl
@@ -75,6 +75,9 @@ in_r(Item, #{ets_tab := Tab} = Q) ->
         '$end_of_table' ->
             in(Item, Q);
         Id ->
+            %% Id is the key of the first item in the queue
+            %% do not allow inverse order enqueue
+            Id =< 1 andalso erlang:error(badarg),
             ets:insert(Tab, {Id - 1, Item}),
             Q
     end.
@@ -95,8 +98,7 @@ out(#{ets_tab := Tab} = Q) ->
         '$end_of_table' ->
             {empty, Q};
         Id ->
-            Item = ets:lookup_element(Tab, Id, 2),
-            ets:delete(Tab, Id),
+            [{_, Item}] = ets:take(Tab, Id),
             {{value, Item}, Q}
     end.
 

--- a/src/replayq_mem_ets_exclusive.erl
+++ b/src/replayq_mem_ets_exclusive.erl
@@ -21,14 +21,14 @@
 
 -export([
     new/1,
-    to_list/1,
+    peek_all/1,
     peek/1,
     is_empty/1,
     in/2,
     in_r/2,
     in_batch/2,
     out/1,
-    purge/1
+    destroy/1
 ]).
 
 -export_type([queue/0]).
@@ -41,9 +41,9 @@ new(_) ->
     Tab = ets:new(?MODULE, [ordered_set, public]),
     #{ets_tab => Tab, next_id => 1}.
 
-%% @doc Convert a queue to a list.
--spec to_list(queue()) -> [term()].
-to_list(#{ets_tab := Tab}) ->
+%% @doc Peek all items from the queue.
+-spec peek_all(queue()) -> [term()].
+peek_all(#{ets_tab := Tab}) ->
     lists:map(fun({_Id, Item}) -> Item end, ets:tab2list(Tab)).
 
 %% @doc Peek the front item of the queue.
@@ -95,14 +95,14 @@ out(#{ets_tab := Tab} = Q) ->
         '$end_of_table' ->
             {empty, Q};
         Id ->
-            [{Id, Item}] = ets:lookup(Tab, Id),
+            Item = ets:lookup_element(Tab, Id, 2),
             ets:delete(Tab, Id),
             {{value, Item}, Q}
     end.
 
-%% @doc Purge the queue.
--spec purge(queue()) -> ok.
-purge(#{ets_tab := Tab}) ->
+%% @doc Destroy the queue.
+-spec destroy(queue()) -> ok.
+destroy(#{ets_tab := Tab}) ->
     case ets:info(Tab, owner) of
         undefined ->
             %% already deleted

--- a/src/replayq_mem_ets_exclusive.erl
+++ b/src/replayq_mem_ets_exclusive.erl
@@ -1,0 +1,113 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% @doc Exclusively owned ETS table for in-memory queue.
+-module(replayq_mem_ets_exclusive).
+
+-behaviour(replayq_mem).
+
+-export([
+    new/1,
+    to_list/1,
+    peek/1,
+    is_empty/1,
+    in/2,
+    in_r/2,
+    in_batch/2,
+    out/1,
+    purge/1
+]).
+
+-export_type([queue/0]).
+
+-opaque queue() :: #{ets_tab := ets:tab(), next_id := non_neg_integer()}.
+
+%% @doc Create a new queue.
+-spec new(_) -> queue().
+new(_) ->
+    Tab = ets:new(?MODULE, [ordered_set, public]),
+    #{ets_tab => Tab, next_id => 1}.
+
+%% @doc Convert a queue to a list.
+-spec to_list(queue()) -> [term()].
+to_list(#{ets_tab := Tab}) ->
+    lists:map(fun({_Id, Item}) -> Item end, ets:tab2list(Tab)).
+
+%% @doc Peek the front item of the queue.
+-spec peek(queue()) -> empty | {value, term()}.
+peek(#{ets_tab := Tab}) ->
+    case ets:first(Tab) of
+        '$end_of_table' ->
+            empty;
+        Id ->
+            Item = ets:lookup_element(Tab, Id, 2),
+            {value, Item}
+    end.
+
+%% @doc Return 'true' if the queue is empty.
+-spec is_empty(queue()) -> boolean().
+is_empty(#{ets_tab := Tab}) ->
+    ets:first(Tab) =:= '$end_of_table'.
+
+%% @doc Enqueue an item to the queue.
+-spec in(term(), queue()) -> queue().
+in(Item, #{ets_tab := Tab, next_id := NextId} = Q) ->
+    ets:insert(Tab, {NextId, Item}),
+    Q#{next_id => NextId + 1}.
+
+%% @doc Enqueue an item in reverse order to the queue.
+-spec in_r(term(), queue()) -> queue().
+in_r(Item, #{ets_tab := Tab} = Q) ->
+    case ets:first(Tab) of
+        '$end_of_table' ->
+            in(Item, Q);
+        Id ->
+            ets:insert(Tab, {Id - 1, Item}),
+            Q
+    end.
+
+%% @doc Enqueue a batch of items to the queue.
+-spec in_batch([term()], queue()) -> queue().
+in_batch(Items, #{ets_tab := Tab, next_id := NextId} = Q) ->
+    {NewNextId, Inserts} = lists:foldl(
+        fun(Item, {Id, Acc}) -> {Id + 1, [{Id, Item} | Acc]} end, {NextId, []}, Items
+    ),
+    ets:insert(Tab, Inserts),
+    Q#{next_id => NewNextId}.
+
+%% @doc Dequeue an item from the queue.
+-spec out(queue()) -> {empty, queue()} | {{value, term()}, queue()}.
+out(#{ets_tab := Tab} = Q) ->
+    case ets:first(Tab) of
+        '$end_of_table' ->
+            {empty, Q};
+        Id ->
+            [{Id, Item}] = ets:lookup(Tab, Id),
+            ets:delete(Tab, Id),
+            {{value, Item}, Q}
+    end.
+
+%% @doc Purge the queue.
+-spec purge(queue()) -> ok.
+purge(#{ets_tab := Tab}) ->
+    case ets:info(Tab, owner) of
+        undefined ->
+            %% already deleted
+            ok;
+        _Owner ->
+            ets:delete(Tab),
+            ok
+    end.

--- a/src/replayq_mem_ets_shared.erl
+++ b/src/replayq_mem_ets_shared.erl
@@ -109,6 +109,9 @@ in_r(Item, Q) ->
     Owner = owner(Q),
     case first_key(Owner) of
         {key, ?KEY(Owner, Id)} ->
+            %% Id is the key of the first item in the queue
+            %% do not allow inverse order enqueue
+            Id =< 1 andalso erlang:error(badarg),
             PrevKey = ?KEY(Owner, Id - 1),
             ets:insert(?ETS_TAB, {PrevKey, Item}),
             Q;
@@ -134,8 +137,7 @@ out(Q) ->
     Owner = owner(Q),
     case first_key(Owner) of
         {key, ?KEY(Owner, Id)} ->
-            Item = ets:lookup_element(?ETS_TAB, ?KEY(Owner, Id), 2),
-            ets:delete(?ETS_TAB, ?KEY(Owner, Id)),
+            [{_, Item}] = ets:take(?ETS_TAB, ?KEY(Owner, Id)),
             {{value, Item}, Q};
         empty ->
             {empty, Q}

--- a/src/replayq_mem_ets_shared.erl
+++ b/src/replayq_mem_ets_shared.erl
@@ -153,7 +153,7 @@ destroy(Q) ->
 %% @doc Purge the queue by owner pid.
 -spec purge_by_owner(pid()) -> ok.
 purge_by_owner(Owner) ->
-    Ms = ets:fun2ms(fun({?KEY(Pid, '_'), _}) when Pid =:= Owner -> true end),
+    Ms = ets:fun2ms(fun({?KEY(Pid, '_'), _}) -> Pid =:= Owner end),
     ets:select_delete(?ETS_TAB, Ms),
     ok.
 

--- a/src/replayq_mem_ets_shared.erl
+++ b/src/replayq_mem_ets_shared.erl
@@ -1,0 +1,168 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% @doc Shared ETS table for in-memory queue.
+%% Each item in the queue is a tuple of the form `{Id, Item}`.
+%% where `Id` is a tuple of `{self(), NextId}` and `NextId` is an increasing integer.
+%% Each owner process can only create one queue.
+-module(replayq_mem_ets_shared).
+
+-behaviour(replayq_mem).
+
+-export([
+    boot_init/0,
+    purge_by_owner/1
+]).
+
+-export([
+    new/1,
+    peek_all/1,
+    peek/1,
+    is_empty/1,
+    in/2,
+    in_r/2,
+    in_batch/2,
+    out/1,
+    destroy/1
+]).
+
+-export_type([queue/0]).
+
+%% parse-transform for ets:fun2ms/1
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-define(ETS_TAB, ?MODULE).
+-define(KEY(PID, ID), {PID, ID}).
+
+-type key() :: {pid(), non_neg_integer()}.
+-type item() :: term().
+-opaque queue() :: #{next_id := non_neg_integer()}.
+
+%% @doc Create the globally shared ETS table.
+-spec boot_init() -> ok.
+boot_init() ->
+    _ = ets:new(?ETS_TAB, [
+        ordered_set,
+        named_table,
+        public,
+        {read_concurrency, true},
+        {write_concurrency, true}
+    ]),
+    ok.
+
+%% @doc Create a new queue.
+-spec new(_) -> queue().
+new(Opts) ->
+    Owner = maps:get(owner, Opts, self()),
+    ok = replayq_registry:register_slot_owner(Owner),
+    #{next_id => 1, owner => Owner}.
+
+%% @doc Peek all items from the queue.
+-spec peek_all(queue()) -> [item()].
+peek_all(Q) ->
+    Owner = owner(Q),
+    Ms = ets:fun2ms(fun({?KEY(Pid, '_'), Item}) when Pid =:= Owner -> Item end),
+    ets:select(?ETS_TAB, Ms).
+
+%% @doc Peek the front item from the queue.
+-spec peek(queue()) -> empty | {value, item()}.
+peek(Q) ->
+    Owner = owner(Q),
+    case first_key(Owner) of
+        {key, Key} ->
+            Item = ets:lookup_element(?ETS_TAB, Key, 2),
+            {value, Item};
+        empty ->
+            empty
+    end.
+
+%% @doc Check if a queue is empty.
+-spec is_empty(queue()) -> boolean().
+is_empty(Q) ->
+    Owner = owner(Q),
+    empty =:= first_key(Owner).
+
+%% @doc Enqueue an item into the queue.
+-spec in(item(), queue()) -> queue().
+in(Item, #{next_id := NextId} = Q) ->
+    Owner = owner(Q),
+    Key = ?KEY(Owner, NextId),
+    ets:insert(?ETS_TAB, {Key, Item}),
+    Q#{next_id => NextId + 1}.
+
+%% @doc Enqueue an item into the queue in reverse order.
+-spec in_r(item(), queue()) -> queue().
+in_r(Item, Q) ->
+    Owner = owner(Q),
+    case first_key(Owner) of
+        {key, ?KEY(Owner, Id)} ->
+            PrevKey = ?KEY(Owner, Id - 1),
+            ets:insert(?ETS_TAB, {PrevKey, Item}),
+            Q;
+        empty ->
+            in(Item, Q)
+    end.
+
+%% @doc Enqueue a batch of items into the queue.
+-spec in_batch([item()], queue()) -> queue().
+in_batch(Items, #{next_id := NextId} = Q) ->
+    Owner = owner(Q),
+    {NewNextId, Inserts} = lists:foldl(
+        fun(Item, {Id, Acc}) -> {Id + 1, [{?KEY(Owner, Id), Item} | Acc]} end,
+        {NextId, []},
+        Items
+    ),
+    ets:insert(?ETS_TAB, Inserts),
+    Q#{next_id => NewNextId}.
+
+%% @doc Dequeue an item from the queue.
+-spec out(queue()) -> {empty, queue()} | {{value, item()}, queue()}.
+out(Q) ->
+    Owner = owner(Q),
+    case first_key(Owner) of
+        {key, ?KEY(Owner, Id)} ->
+            Item = ets:lookup_element(?ETS_TAB, ?KEY(Owner, Id), 2),
+            ets:delete(?ETS_TAB, ?KEY(Owner, Id)),
+            {{value, Item}, Q};
+        empty ->
+            {empty, Q}
+    end.
+
+%% @doc Destroy the queue.
+-spec destroy(queue()) -> ok.
+destroy(Q) ->
+    Owner = owner(Q),
+    ok = purge_by_owner(Owner),
+    ok = replayq_registry:deregister_slot_owner(Owner).
+
+%% @doc Purge the queue by owner pid.
+-spec purge_by_owner(pid()) -> ok.
+purge_by_owner(Owner) ->
+    Ms = ets:fun2ms(fun({?KEY(Pid, '_'), _}) when Pid =:= Owner -> true end),
+    ets:select_delete(?ETS_TAB, Ms),
+    ok.
+
+%% Get the first key in the queue.
+-spec first_key(pid()) -> empty | {key, key()}.
+first_key(Owner) ->
+    case ets:next(?ETS_TAB, ?KEY(Owner, 0)) of
+        ?KEY(Pid, _) = Key when Pid =:= Owner ->
+            {key, Key};
+        _ ->
+            empty
+    end.
+
+owner(#{owner := Owner}) -> Owner.

--- a/src/replayq_mem_queue.erl
+++ b/src/replayq_mem_queue.erl
@@ -26,7 +26,8 @@
     in/2,
     in_r/2,
     in_batch/2,
-    out/1
+    out/1,
+    purge/1
 ]).
 
 -export_type([queue/1]).
@@ -70,6 +71,11 @@ in_batch(Items, Q) ->
 %% @doc Dequeue an item from the queue.
 -spec out(queue(Term)) -> {empty, queue(Term)} | {{value, Term}, queue(Term)}.
 out(Q) -> queue:out(Q).
+
+%% @doc Purge the queue.
+%% This implementation does nothing.
+-spec purge(queue(_)) -> ok.
+purge(_Q) -> ok.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/src/replayq_mem_queue.erl
+++ b/src/replayq_mem_queue.erl
@@ -20,14 +20,14 @@
 
 -export([
     new/1,
-    to_list/1,
+    peek_all/1,
     peek/1,
     is_empty/1,
     in/2,
     in_r/2,
     in_batch/2,
     out/1,
-    purge/1
+    destroy/1
 ]).
 
 -export_type([queue/1]).
@@ -38,9 +38,9 @@
 -spec new(_) -> queue(term()).
 new(_) -> queue:new().
 
-%% @doc Convert a queue to a list.
--spec to_list(queue(Term)) -> [Term].
-to_list(Q) -> queue:to_list(Q).
+%% @doc Peek all items from the queue.
+-spec peek_all(queue(Term)) -> [Term].
+peek_all(Q) -> queue:to_list(Q).
 
 %% @doc Peek the front item of the queue.
 -spec peek(queue(Term)) -> empty | {value, Term}.
@@ -72,10 +72,10 @@ in_batch(Items, Q) ->
 -spec out(queue(Term)) -> {empty, queue(Term)} | {{value, Term}, queue(Term)}.
 out(Q) -> queue:out(Q).
 
-%% @doc Purge the queue.
+%% @doc Destroy the queue.
 %% This implementation does nothing.
--spec purge(queue(_)) -> ok.
-purge(_Q) -> ok.
+-spec destroy(queue(_)) -> ok.
+destroy(_Q) -> ok.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/src/replayq_registry.erl
+++ b/src/replayq_registry.erl
@@ -105,7 +105,7 @@ handle_call(#register_slot_owner{pid = Pid}, _From, #{slot_owners := Owners0} = 
     case is_map_key(Pid, Owners0) of
         false ->
             Ref = erlang:monitor(process, Pid),
-            {reply, ok, State0#{slot_owners => Owners0#{Pid => Ref}}};
+            {reply, ok, State0#{slot_owners := Owners0#{Pid => Ref}}};
         true ->
             {reply, {error, already_registered}, State0}
     end;
@@ -115,7 +115,7 @@ handle_call(#deregister_slot_owner{pid = Pid}, _From, #{slot_owners := Owners0} 
             {reply, ok, State0};
         Ref ->
             erlang:demonitor(Ref, [flush]),
-            {reply, ok, State0#{slot_owners => maps:remove(Pid, Owners0)}}
+            {reply, ok, State0#{slot_owners := maps:remove(Pid, Owners0)}}
     end;
 handle_call(_Call, _From, State) ->
     {reply, {error, unknown_call}, State}.
@@ -128,7 +128,7 @@ handle_info({'DOWN', _Ref, process, Pid, _Info}, #{slot_owners := Owners0} = Sta
 ->
     Owners = maps:remove(Pid, Owners0),
     ok = replayq_mem_ets_shared:purge_by_owner(Pid),
-    {noreply, State0#{slot_owners => Owners}};
+    {noreply, State0#{slot_owners := Owners}};
 handle_info({'EXIT', Pid, _Reason}, #{committers := Committers0} = State0) when
     is_map_key(Pid, Committers0)
 ->

--- a/src/replayq_registry.erl
+++ b/src/replayq_registry.erl
@@ -20,9 +20,10 @@
 %% API
 -export([
     start_link/0,
-
     register_committer/2,
-    deregister_committer/1
+    deregister_committer/1,
+    register_slot_owner/1,
+    deregister_slot_owner/1
 ]).
 
 %% `gen_server' API
@@ -40,7 +41,8 @@
 %% call/cast/info events
 -record(register_committer, {dir :: string() | binary(), pid :: pid()}).
 -record(deregister_committer, {pid :: pid()}).
-
+-record(register_slot_owner, {pid :: pid()}).
+-record(deregister_slot_owner, {pid :: pid()}).
 %%------------------------------------------------------------------------------
 %% API
 %%------------------------------------------------------------------------------
@@ -56,13 +58,22 @@ register_committer(Dir0, Pid) ->
 deregister_committer(Pid) ->
     gen_server:call(?MODULE, #deregister_committer{pid = Pid}, infinity).
 
+%% @doc Register a slot owner in the global shared queue.
+-spec register_slot_owner(pid()) -> ok | {error, already_registered}.
+register_slot_owner(Pid) ->
+    gen_server:call(?MODULE, #register_slot_owner{pid = Pid}, infinity).
+
+-spec deregister_slot_owner(pid()) -> ok.
+deregister_slot_owner(Pid) ->
+    gen_server:call(?MODULE, #deregister_slot_owner{pid = Pid}, infinity).
+
 %%------------------------------------------------------------------------------
 %% `gen_server' API
 %%------------------------------------------------------------------------------
 
 init(_Opts) ->
     process_flag(trap_exit, true),
-    State = #{committers => #{}},
+    State = #{committers => #{}, slot_owners => #{}},
     {ok, State}.
 
 handle_call(#register_committer{dir = Dir, pid = Pid}, _From, State0) ->
@@ -90,12 +101,34 @@ handle_call(#deregister_committer{pid = Pid}, _From, #{committers := Committers0
             {_, State} = pop_committer(State0, Pid),
             {reply, ok, State}
     end;
+handle_call(#register_slot_owner{pid = Pid}, _From, #{slot_owners := Owners0} = State0) ->
+    case is_map_key(Pid, Owners0) of
+        false ->
+            Ref = erlang:monitor(process, Pid),
+            {reply, ok, State0#{slot_owners => Owners0#{Pid => Ref}}};
+        true ->
+            {reply, {error, already_registered}, State0}
+    end;
+handle_call(#deregister_slot_owner{pid = Pid}, _From, #{slot_owners := Owners0} = State0) ->
+    case maps:get(Pid, Owners0, undefined) of
+        undefined ->
+            {reply, ok, State0};
+        Ref ->
+            erlang:demonitor(Ref, [flush]),
+            {reply, ok, State0#{slot_owners => maps:remove(Pid, Owners0)}}
+    end;
 handle_call(_Call, _From, State) ->
     {reply, {error, unknown_call}, State}.
 
 handle_cast(_Cast, State) ->
     {noreply, State}.
 
+handle_info({'DOWN', _Ref, process, Pid, _Info}, #{slot_owners := Owners0} = State0) when
+    is_map_key(Pid, Owners0)
+->
+    Owners = maps:remove(Pid, Owners0),
+    ok = replayq_mem_ets_shared:purge_by_owner(Pid),
+    {noreply, State0#{slot_owners => Owners}};
 handle_info({'EXIT', Pid, _Reason}, #{committers := Committers0} = State0) when
     is_map_key(Pid, Committers0)
 ->

--- a/src/replayq_sup.erl
+++ b/src/replayq_sup.erl
@@ -35,6 +35,7 @@ start_link() ->
 %%------------------------------------------------------------------------------
 
 init([]) ->
+    ok = replayq_mem_ets_shared:boot_init(),
     Registry = worker_spec(replayq_registry),
     SupFlags = #{
         strategy => one_for_one,

--- a/test/replayq_SUITE.erl
+++ b/test/replayq_SUITE.erl
@@ -36,8 +36,8 @@ all_cases() ->
 groups() ->
     [
         {queue, [], all_cases()},
-        {ets_exclusive, [], all_cases() ++ [in_r_not_allowed]},
-        {ets_shared, [], all_cases() ++ [in_r_not_allowed, owner_down_cause_purge]}
+        {ets_exclusive, [], all_cases() },
+        {ets_shared, [], all_cases() ++ [owner_down_cause_purge]}
     ].
 
 init_per_group(Group, Config) ->
@@ -677,13 +677,6 @@ test_pop_bytes(CtConfig, Config, BytesMode) ->
     end,
     ok = replayq:close(Q0),
     ok.
-
-in_r_not_allowed(CtConfig) ->
-    Q = open(CtConfig, #{mem_only => true}),
-    Q1 = replayq:append(Q, [<<"item1">>]),
-    #{in_mem := InMem, mem_queue_module := MemQueueModule} = Q1,
-    ?assertError(badarg, replayq_mem:in_r(MemQueueModule, <<"item">>, InMem)),
-    ok = replayq:close(Q1).
 
 owner_down_cause_purge(CtConfig) ->
     {Owner, Ref} = spawn_monitor(fun() ->

--- a/test/replayq_SUITE.erl
+++ b/test/replayq_SUITE.erl
@@ -20,7 +20,11 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    [{group, queue}, {group, ets_exclusive}].
+    [
+        {group, queue},
+        {group, ets_exclusive},
+        {group, ets_shared}
+    ].
 
 all_cases() ->
     [
@@ -32,7 +36,8 @@ all_cases() ->
 groups() ->
     [
         {queue, [], all_cases()},
-        {ets_exclusive, [], all_cases()}
+        {ets_exclusive, [], all_cases()},
+        {ets_shared, [], all_cases()}
     ].
 
 init_per_group(Group, Config) ->
@@ -710,7 +715,8 @@ open(CtConfig, Config0) ->
     Config =
         case proplists:get_value(ct_group, CtConfig) of
             queue -> Config0;
-            ets_exclusive -> Config0#{mem_queue_module => replayq_mem_ets_exclusive}
+            ets_exclusive -> Config0#{mem_queue_module => replayq_mem_ets_exclusive};
+            ets_shared -> Config0#{mem_queue_module => replayq_mem_ets_shared}
         end,
     replayq:open(Config).
 

--- a/test/replayq_SUITE.erl
+++ b/test/replayq_SUITE.erl
@@ -36,8 +36,8 @@ all_cases() ->
 groups() ->
     [
         {queue, [], all_cases()},
-        {ets_exclusive, [], all_cases()},
-        {ets_shared, [], all_cases()}
+        {ets_exclusive, [], all_cases() ++ [in_r_not_allowed]},
+        {ets_shared, [], all_cases() ++ [in_r_not_allowed]}
     ].
 
 init_per_group(Group, Config) ->
@@ -677,6 +677,13 @@ test_pop_bytes(CtConfig, Config, BytesMode) ->
     end,
     ok = replayq:close(Q0),
     ok.
+
+in_r_not_allowed(CtConfig) ->
+    Q = open(CtConfig, #{mem_only => true}),
+    Q1 = replayq:append(Q, [<<"item1">>]),
+    #{in_mem := InMem, mem_queue_module := MemQueueModule} = Q1,
+    ?assertError(badarg, replayq_mem:in_r(MemQueueModule, <<"item">>, InMem)),
+    ok = replayq:close(Q1).
 
 %% helpers ===========================================================
 

--- a/test/replayq_SUITE.erl
+++ b/test/replayq_SUITE.erl
@@ -36,7 +36,7 @@ all_cases() ->
 groups() ->
     [
         {queue, [], all_cases()},
-        {ets_exclusive, [], all_cases() },
+        {ets_exclusive, [], all_cases()},
         {ets_shared, [], all_cases() ++ [owner_down_cause_purge]}
     ].
 

--- a/test/replayq_SUITE.erl
+++ b/test/replayq_SUITE.erl
@@ -15,16 +15,31 @@
 %%--------------------------------------------------------------------
 
 -module(replayq_SUITE).
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
+    [{group, queue}, {group, ets_exclusive}].
+
+all_cases() ->
     [
         F
      || {F, _} <- ?MODULE:module_info(exports),
         is_t_function(atom_to_list(F))
     ].
+
+groups() ->
+    [
+        {queue, [], all_cases()},
+        {ets_exclusive, [], all_cases()}
+    ].
+
+init_per_group(Group, Config) ->
+    [{ct_group, Group} | Config].
+
+end_per_group(_Group, _Config) ->
+    ok.
 
 is_t_function("t_" ++ _) -> true;
 is_t_function(_) -> false.
@@ -40,37 +55,37 @@ end_per_suite(_Config) ->
     ok.
 
 %% the very first run
-t_init(_Config) ->
+t_init(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 100},
-    Q1 = replayq:open(Config),
+    Q1 = open(CtConfig, Config),
     ?assertEqual(0, replayq:count(Q1)),
     ?assertEqual(0, replayq:bytes(Q1)),
     ok = replayq:close(Q1),
-    Q2 = replayq:open(Config),
+    Q2 = open(CtConfig, Config),
     ?assertEqual(0, replayq:count(Q2)),
     ?assertEqual(0, replayq:bytes(Q2)),
     ok = replayq:close(Q2),
     ok = cleanup(Dir).
 
-t_reopen(_Config) ->
+t_reopen(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 100},
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>]),
     ok = replayq:close(Q1),
-    Q2 = replayq:open(Config),
+    Q2 = open(CtConfig, Config),
     ?assertEqual(2, replayq:count(Q2)),
     ?assertEqual(10, replayq:bytes(Q2)),
     ok = cleanup(Dir).
 
-t_volatile(_Config) ->
+t_volatile(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 100},
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>]),
     ok = replayq:close(Q1),
-    Q2 = replayq:open(Config#{offload => {true, volatile}}),
+    Q2 = open(CtConfig, Config#{offload => {true, volatile}}),
     ?assertEqual(0, replayq:count(Q2)),
     ?assertEqual(0, replayq:bytes(Q2)),
     {Q3, _QAckRef, Items} = replayq:pop(Q2, #{count_limit => 10}),
@@ -80,10 +95,10 @@ t_volatile(_Config) ->
 
 %% when popping from in-mem segment, the segment size stats may overflow
 %% but not consuming as much memory
-t_offload_in_mem_seg_overflow(_Config) ->
+t_offload_in_mem_seg_overflow(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 11, offload => true},
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     % in mem, one byte left
     Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>]),
     % not offloading to disk yet
@@ -99,10 +114,10 @@ t_offload_in_mem_seg_overflow(_Config) ->
     ok = replayq:close(Q3),
     ok = cleanup(Dir).
 
-t_offload_file(_Config) ->
+t_offload_file(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 10, offload => true},
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     % in mem
     Q1 = replayq:append(Q0, [<<"item1">>]),
     ?assertMatch([], list_segments(Dir)),
@@ -131,10 +146,10 @@ t_offload_file(_Config) ->
     ok = replayq:close(Q7),
     ok = cleanup(Dir).
 
-t_offload_reopen(_Config) ->
+t_offload_reopen(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 100, offload => true},
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>]),
     ?assertMatch(#{w_cur := #{fd := no_fd}}, Q1),
     % should be filtered out
@@ -142,7 +157,7 @@ t_offload_reopen(_Config) ->
     {Q2, _AckRef, Items} = replayq:pop(Q1, #{count_limit => 1}),
     ?assertEqual([<<"item1">>], Items),
     ok = replayq:close(Q2),
-    Q3 = replayq:open(Config),
+    Q3 = open(CtConfig, Config),
     ?assertEqual(2, replayq:count(Q3)),
     ?assertEqual(10, replayq:bytes(Q3)),
     {Q4, AckRef1, Items1} = replayq:pop(Q3, #{count_limit => 2}),
@@ -150,15 +165,15 @@ t_offload_reopen(_Config) ->
     ?assertEqual([filename(1), filename(2)], list_segments(Dir)),
     ok = replayq:ack_sync(Q4, AckRef1),
     ok = replayq:close(Q4),
-    Q5 = replayq:open(Config),
+    Q5 = open(CtConfig, Config),
     ?assertEqual(0, replayq:count(Q5)),
     ?assertEqual(0, replayq:bytes(Q5)),
     ok = cleanup(Dir).
 
-t_reopen_v0(_Config) ->
+t_reopen_v0(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 1000},
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     % inspect the opaque internal structure for test
     #{w_cur := #{fd := Fd}} = Q0,
     % append a version-0 item
@@ -166,7 +181,7 @@ t_reopen_v0(_Config) ->
     % append a version-1 itme
     Q2 = replayq:append(Q0, [<<"item2">>]),
     ok = replayq:close(Q2),
-    Q3 = replayq:open(Config),
+    Q3 = open(CtConfig, Config),
     {Q4, _AckRef, Items} = replayq:pop(Q3, #{count_limit => 3}),
     %% do not expect item3 because it was appended to a corrupted tail
     ?assertEqual([<<"item1">>, <<"item2">>], Items),
@@ -174,12 +189,12 @@ t_reopen_v0(_Config) ->
     ok = replayq:close(Q4),
     ok = cleanup(Dir).
 
-t_append_pop_disk_default_marshaller(_Config) ->
+t_append_pop_disk_default_marshaller(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 1},
-    test_append_pop_disk(Config).
+    test_append_pop_disk(CtConfig, Config).
 
-t_append_pop_disk_my_marshaller(_Config) ->
+t_append_pop_disk_my_marshaller(CtConfig) ->
     Dir = ?DIR,
     Config = #{
         dir => Dir,
@@ -190,10 +205,10 @@ t_append_pop_disk_my_marshaller(_Config) ->
             (I) -> <<"mmp", I/binary>>
         end
     },
-    test_append_pop_disk(Config).
+    test_append_pop_disk(CtConfig, Config).
 
-test_append_pop_disk(#{dir := Dir} = Config) ->
-    Q0 = replayq:open(Config),
+test_append_pop_disk(CtConfig, #{dir := Dir} = Config) ->
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>]),
     Q2 = replayq:append(Q1, [<<"item3">>]),
     ?assertEqual(<<"item1">>, replayq:peek(Q2)),
@@ -205,7 +220,7 @@ test_append_pop_disk(#{dir := Dir} = Config) ->
     %% stop without acking
     ok = replayq:close(Q3),
     %% open again expect to receive the same items
-    Q4 = replayq:open(Config),
+    Q4 = open(CtConfig, Config),
     {Q5, AckRef1, Items1} = replayq:pop(Q4, #{
         count_limit => 5,
         bytes_limit => 1000
@@ -214,7 +229,7 @@ test_append_pop_disk(#{dir := Dir} = Config) ->
     ?assertEqual(Items, Items1),
     lists:foreach(fun(_) -> ok = replayq:ack(Q5, AckRef) end, lists:seq(1, 100)),
     ok = replayq:close(Q5),
-    Q6 = replayq:open(Config),
+    Q6 = open(CtConfig, Config),
     ?assert(replayq:is_empty(Q6)),
     ?assertEqual(empty, replayq:peek(Q6)),
     ?assertEqual({Q6, nothing_to_ack, []}, replayq:pop(Q6, #{})),
@@ -222,11 +237,11 @@ test_append_pop_disk(#{dir := Dir} = Config) ->
     ok = replayq:close(Q6),
     ok = cleanup(Dir).
 
-t_append_pop_mem_default_marshaller(_Config) ->
+t_append_pop_mem_default_marshaller(CtConfig) ->
     Config = #{mem_only => true},
-    test_append_pop_mem(Config).
+    test_append_pop_mem(CtConfig, Config).
 
-t_append_pop_mem_my_marshaller(_Config) ->
+t_append_pop_mem_my_marshaller(CtConfig) ->
     Config = #{
         mem_only => true,
         sizer => fun(Item) -> size(Item) end,
@@ -235,10 +250,10 @@ t_append_pop_mem_my_marshaller(_Config) ->
             (I) -> <<"mmp", I/binary>>
         end
     },
-    test_append_pop_mem(Config).
+    test_append_pop_mem(CtConfig, Config).
 
-test_append_pop_mem(Config) ->
-    Q0 = replayq:open(Config),
+test_append_pop_mem(CtConfig, Config) ->
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>]),
     Q2 = replayq:append(Q1, [<<"item3">>]),
     ?assertEqual(<<"item1">>, replayq:peek(Q2)),
@@ -250,7 +265,7 @@ test_append_pop_mem(Config) ->
     %% stop without acking
     ok = replayq:close(Q3),
     %% open again expect to receive the same items
-    Q4 = replayq:open(Config),
+    Q4 = open(CtConfig, Config),
     {Q5, _AckRef1, _Items1} =
         replayq:pop(Q4, #{count_limit => 5, bytes_limit => 1000}),
     ?assertEqual(empty, replayq:peek(Q5)),
@@ -258,7 +273,7 @@ test_append_pop_mem(Config) ->
     ok = replayq:ack(Q5, nothing_to_ack),
     ok = replayq:close(Q5).
 
-t_append_max_total_bytes_mem(_Config) ->
+t_append_max_total_bytes_mem(CtConfig) ->
     Config = #{
         mem_only => true,
         sizer => fun(Item) -> size(Item) end,
@@ -268,10 +283,10 @@ t_append_max_total_bytes_mem(_Config) ->
         end,
         max_total_bytes => 10
     },
-    test_append_max_total_bytes(Config),
+    test_append_max_total_bytes(CtConfig, Config),
     ok.
 
-t_append_max_total_bytes_disk(_Config) ->
+t_append_max_total_bytes_disk(CtConfig) ->
     Dir = ?DIR,
     Config = #{
         dir => Dir,
@@ -283,11 +298,11 @@ t_append_max_total_bytes_disk(_Config) ->
         end,
         max_total_bytes => 10
     },
-    test_append_max_total_bytes(Config),
+    test_append_max_total_bytes(CtConfig, Config),
     ok = cleanup(Dir).
 
-test_append_max_total_bytes(Config) ->
-    Q0 = replayq:open(Config),
+test_append_max_total_bytes(CtConfig, Config) ->
+    Q0 = open(CtConfig, Config),
     ?assertEqual(-10, replayq:overflow(Q0)),
     Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>, <<"item3">>, <<"item4">>]),
     ?assertEqual(10, replayq:overflow(Q1)),
@@ -295,18 +310,18 @@ test_append_max_total_bytes(Config) ->
     ?assertEqual(0, replayq:overflow(Q2)),
     ok = replayq:close(Q2).
 
-t_pop_limit_disk(_Config) ->
+t_pop_limit_disk(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 1},
-    ok = test_pop_limit(Config),
+    ok = test_pop_limit(CtConfig, Config),
     ok = cleanup(Dir).
 
-t_pop_limit_mem(_Config) ->
+t_pop_limit_mem(CtConfig) ->
     Config = #{mem_only => true},
-    ok = test_pop_limit(Config).
+    ok = test_pop_limit(CtConfig, Config).
 
-test_pop_limit(Config) ->
-    Q0 = replayq:open(Config),
+test_pop_limit(CtConfig, Config) ->
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>]),
     Q2 = replayq:append(Q1, [<<"item3">>]),
     {Q3, _AckRef1, Items1} = replayq:pop(Q2, #{
@@ -321,10 +336,10 @@ test_pop_limit(Config) ->
     ?assertEqual([<<"item2">>], Items2),
     ok = replayq:close(Q4).
 
-t_commit_in_the_middle(_Config) ->
+t_commit_in_the_middle(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 1000},
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(Q0, [<<"item1">>, <<"item2">>]),
     Q2 = replayq:append(Q1, [<<"item3">>]),
     {Q3, AckRef1, Items1} = replayq:pop(Q2, #{count_limit => 1}),
@@ -335,7 +350,7 @@ t_commit_in_the_middle(_Config) ->
     ?assertEqual(2, replayq:count(Q3)),
     ?assertEqual([<<"item1">>], Items1),
     ok = replayq:close(Q3),
-    Q4 = replayq:open(Config),
+    Q4 = open(CtConfig, Config),
     {Q5, _AckRef2, Items2} = replayq:pop(Q4, #{count_limit => 1}),
     ?assertEqual([<<"item2">>], Items2),
     ?assertEqual(1, replayq:count(Q5)),
@@ -343,12 +358,12 @@ t_commit_in_the_middle(_Config) ->
     ok = replayq:close(Q5),
     ok = cleanup(Dir).
 
-t_first_segment_corrupted(_Config) ->
+t_first_segment_corrupted(CtConfig) ->
     Dir = ?DIR,
     SegBytes = 10,
     Config = #{dir => Dir, seg_bytes => SegBytes},
     Item = iolist_to_binary(lists:duplicate(SegBytes, "a")),
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     ok = corrupt(Q0),
     %% to the first (corrputed) segment
     Q1 = replayq:append(Q0, [Item]),
@@ -358,7 +373,7 @@ t_first_segment_corrupted(_Config) ->
     ?assertMatch(#{head_segno := 1, w_cur := #{segno := 3}}, Q2),
     replayq:close(Q2),
     %% reopen to discover that the first segment is corrupted
-    Q3 = replayq:open(Config),
+    Q3 = open(CtConfig, Config),
     ?assertEqual(1, replayq:count(Q3)),
     {Q4, _AckRef, Items} = replayq:pop(Q3, #{count_limit => 3}),
     ?assertEqual([Item], Items),
@@ -366,12 +381,12 @@ t_first_segment_corrupted(_Config) ->
     ok = replayq:close(Q4),
     ok = cleanup(Dir).
 
-t_second_segment_corrupted(_Config) ->
+t_second_segment_corrupted(CtConfig) ->
     Dir = ?DIR,
     SegBytes = 10,
     Config = #{dir => Dir, seg_bytes => SegBytes},
     Item = iolist_to_binary(lists:duplicate(SegBytes, "a")),
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     %% to the first segment
     Q1 = replayq:append(Q0, [Item]),
     ok = corrupt(Q1),
@@ -383,7 +398,7 @@ t_second_segment_corrupted(_Config) ->
     ?assertMatch(#{head_segno := 1, w_cur := #{segno := 4}}, Q3),
     replayq:close(Q3),
     %% reopen to discover that the second segment is corrupted
-    Q4 = replayq:open(Config),
+    Q4 = open(CtConfig, Config),
     ?assertEqual(2, replayq:count(Q4)),
     {Q5, _AckRef, Items} = replayq:pop(Q4, #{count_limit => 3}),
     ?assertEqual([Item, Item], Items),
@@ -391,12 +406,12 @@ t_second_segment_corrupted(_Config) ->
     ok = replayq:close(Q5),
     ok = cleanup(Dir).
 
-t_last_segment_corrupted(_Config) ->
+t_last_segment_corrupted(CtConfig) ->
     Dir = ?DIR,
     SegBytes = 10,
     Config = #{dir => Dir, seg_bytes => SegBytes},
     Item = iolist_to_binary(lists:duplicate(SegBytes, "a")),
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     %% to the first segment
     Q1 = replayq:append(Q0, [Item]),
     %% to the second segment
@@ -406,7 +421,7 @@ t_last_segment_corrupted(_Config) ->
     Q3 = replayq:append(Q2, [<<"thridsegment">>]),
     replayq:close(Q3),
     %% reopen to discover that the third segment is corrupted
-    Q4 = replayq:open(Config),
+    Q4 = open(CtConfig, Config),
     ?assertEqual(2, replayq:count(Q4)),
     {Q5, _AckRef, Items} = replayq:pop(Q4, #{count_limit => 3}),
     ?assertEqual([Item, Item], Items),
@@ -418,22 +433,22 @@ t_last_segment_corrupted(_Config) ->
     replayq:ack(Q7, AckRef),
     ok = replayq:close(Q7),
     %% try to open again to check size
-    Q8 = replayq:open(Config),
+    Q8 = open(CtConfig, Config),
     ?assert(replayq:is_empty(Q8)),
     replayq:ack(Q7, AckRef),
     ok = cleanup(Dir).
 
-t_corrupted_segment(_Config) ->
-    ?assert(test_corrupted_segment(<<"foo">>)),
-    ?assert(test_corrupted_segment(<<0:8, 0:32, 1:32, 1:8>>)),
-    ?assert(test_corrupted_segment(<<0:8, 0:32, 0:32, "randomtail">>)),
-    ?assert(test_corrupted_segment(<<1:8, 0:32, 1:32, 1:8>>)),
-    ?assert(test_corrupted_segment(<<1:8, 841265288:32, 0:32, 1:32, 1:8>>)).
+t_corrupted_segment(CtConfig) ->
+    ?assert(test_corrupted_segment(CtConfig, <<"foo">>)),
+    ?assert(test_corrupted_segment(CtConfig, <<0:8, 0:32, 1:32, 1:8>>)),
+    ?assert(test_corrupted_segment(CtConfig, <<0:8, 0:32, 0:32, "randomtail">>)),
+    ?assert(test_corrupted_segment(CtConfig, <<1:8, 0:32, 1:32, 1:8>>)),
+    ?assert(test_corrupted_segment(CtConfig, <<1:8, 841265288:32, 0:32, 1:32, 1:8>>)).
 
-test_corrupted_segment(BadBytes) ->
+test_corrupted_segment(CtConfig, BadBytes) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 1000},
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     Item2 = <<>>,
     Q1 = replayq:append(Q0, [<<"item1">>, Item2]),
     % inspect the opaque internal structure for test
@@ -442,7 +457,7 @@ test_corrupted_segment(BadBytes) ->
     file:write(Fd, BadBytes),
     Q2 = replayq:append(Q0, [<<"item3">>]),
     ok = replayq:close(Q2),
-    Q3 = replayq:open(Config),
+    Q3 = open(CtConfig, Config),
     {Q4, _AckRef, Items} = replayq:pop(Q3, #{count_limit => 3}),
     %% do not expect item3 because it was appended to a corrupted tail
     ?assertEqual([<<"item1">>, Item2], Items),
@@ -451,10 +466,10 @@ test_corrupted_segment(BadBytes) ->
     ok = cleanup(Dir),
     true.
 
-t_comitter_crash(_Config) ->
+t_comitter_crash(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 1000},
-    #{committer := Committer} = replayq:open(Config),
+    #{committer := Committer} = open(CtConfig, Config),
     erlang:process_flag(trap_exit, true),
     Committer ! <<"foo">>,
     receive
@@ -464,21 +479,21 @@ t_comitter_crash(_Config) ->
 
 %% Checks that our spawned committer can register a name for itself when using filepaths
 %% larger than 255 bytes.
-t_huge_filepath(_Config) ->
+t_huge_filepath(CtConfig) ->
     Dir0 = ?DIR,
     Dir = filename:join(Dir0, binary:copy(<<"a">>, 255)),
     Config = #{dir => Dir, seg_bytes => 1000},
-    Q = #{committer := Committer} = replayq:open(Config),
+    Q = #{committer := Committer} = open(CtConfig, Config),
     ?assert(is_process_alive(Committer)),
     replayq:close(Q),
     ok.
 
 %% Checks that we don't allow having the same directory open by multiple replayqs.
-t_same_directory_committer_clash(_Config) ->
+t_same_directory_committer_clash(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 1000},
-    Q1 = replayq:open(Config),
-    try replayq:open(Config) of
+    Q1 = open(CtConfig, Config),
+    try open(CtConfig, Config) of
         Q2 -> error({"should not allow opening a second replayq", Q2})
     catch
         error:{badmatch, {error, already_registered}} ->
@@ -487,36 +502,36 @@ t_same_directory_committer_clash(_Config) ->
     replayq:close(Q1),
     ok.
 
-t_is_mem_only_mem(_Config) ->
-    Q = replayq:open(#{mem_only => true}),
+t_is_mem_only_mem(CtConfig) ->
+    Q = open(CtConfig, #{mem_only => true}),
     true = replayq:is_mem_only(Q),
     ok = replayq:close(Q).
 
-t_is_mem_only_disk(_Config) ->
+t_is_mem_only_disk(CtConfig) ->
     Config = #{dir => ?DIR, seg_bytes => 100},
-    Q = replayq:open(Config),
+    Q = open(CtConfig, Config),
     false = replayq:is_mem_only(Q),
     ok = replayq:close(Q).
 
-t_stop_before_mem(_Config) ->
+t_stop_before_mem(CtConfig) ->
     Config = #{mem_only => true},
-    stop_before_test(Config),
-    stop_before_readme_example_test(Config).
+    stop_before_test(CtConfig, Config),
+    stop_before_readme_example_test(CtConfig, Config).
 
-t_stop_before_disk(_Config) ->
+t_stop_before_disk(CtConfig) ->
     Config1 = #{
         dir => ?DIR,
         seg_bytes => 100
     },
-    stop_before_test(Config1),
+    stop_before_test(CtConfig, Config1),
     Config2 = #{
         dir => filename:join([?DIR, "example"]),
         seg_bytes => 100
     },
-    stop_before_readme_example_test(Config2).
+    stop_before_readme_example_test(CtConfig, Config2).
 
-stop_before_test(Config) ->
-    Q0 = replayq:open(Config),
+stop_before_test(CtConfig, Config) ->
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(Q0, [<<"1">>, <<"2">>, <<"3">>, <<"4">>, <<"5">>]),
     StopBeforeFun =
         fun
@@ -540,8 +555,8 @@ stop_before_test(Config) ->
     ok = replayq:close(Q2).
 
 %% Test that the example in the readme file works
-stop_before_readme_example_test(Config) ->
-    Q0 = replayq:open(Config),
+stop_before_readme_example_test(CtConfig, Config) ->
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(
         Q0,
         [
@@ -584,10 +599,10 @@ stop_before_readme_example_test(Config) ->
     ok = replayq:ack(Q5, AckRef4),
     ok = replayq:close(Q5).
 
-t_corrupted_commit(_Config) ->
+t_corrupted_commit(CtConfig) ->
     Dir = ?DIR,
     Config = #{dir => Dir, seg_bytes => 1000},
-    Q0 = replayq:open(Config),
+    Q0 = open(CtConfig, Config),
     Q1 = replayq:append(Q0, [<<"item1">>]),
     {Q2, AckRef, _} = replayq:pop(Q1, #{count_limit => 3}),
     ok = replayq:ack_sync(Q2, AckRef),
@@ -597,55 +612,73 @@ t_corrupted_commit(_Config) ->
 
     ok = file:write_file(CommitFile, <<>>),
     %% assert no crash
-    Q3 = replayq:open(Config),
+    Q3 = open(CtConfig, Config),
     ok = replayq:close(Q3),
 
     ok = file:write_file(CommitFile, <<"bad-erlang-term">>),
     %% assert no crash
-    Q4 = replayq:open(Config),
+    Q4 = open(CtConfig, Config),
     ok = replayq:close(Q4),
     ok = cleanup(Dir).
 
-t_pop_at_least_bytes_mem(_Config) ->
+t_pop_bytes_mem(CtConfig) ->
     Config = #{
         mem_only => true,
         seg_bytes => 1000,
         sizer => fun(Item) -> size(Item) end
     },
-    test_pop_at_least_bytes(Config).
+    ok = test_pop_bytes(CtConfig, Config, default),
+    ok = test_pop_bytes(CtConfig, Config, at_most),
+    ok = test_pop_bytes(CtConfig, Config, at_least),
+    ok.
 
-t_pop_at_least_bytes_disk(_Config) ->
+t_pop_bytes_disk(CtConfig) ->
     Dir = ?DIR,
     Config = #{
         dir => Dir,
         seg_bytes => 1000,
         sizer => fun(Item) -> size(Item) end
     },
-    test_pop_at_least_bytes(Config),
+    ok = test_pop_bytes(CtConfig, Config, default),
+    ok = cleanup(Dir),
+    ok = test_pop_bytes(CtConfig, Config, at_most),
+    ok = cleanup(Dir),
+    ok = test_pop_bytes(CtConfig, Config, at_least),
     ok = cleanup(Dir).
 
-test_pop_at_least_bytes(Config) ->
-    Q0 = replayq:open(Config),
+test_pop_bytes(CtConfig, Config, BytesMode) ->
+    Q0 = open(CtConfig, Config),
     %% Two 5 bytes elements
     Item1 = <<"12345">>,
     Item2 = <<"67890">>,
     Q1 = replayq:append(Q0, [Item1, Item2]),
     ItemSize = 5,
     ?assertEqual(ItemSize * 2, replayq:bytes(Q1)),
-    %% Default behavior: we pop _at most_ N bytes, and return at least 1 item, if any.
-    %% Asking for less bytes than the 2 elements should yield singleton batch.
-    {_Q2, _Ack2, [Item1]} = replayq:pop(Q1, #{count_limit => 10, bytes_limit => ItemSize - 1}),
-    {_Q3, _Ack3, [Item1]} = replayq:pop(Q1, #{
-        count_limit => 10, bytes_limit => {at_most, ItemSize - 1}
-    }),
-    %% ... but dropping _at least_ less bytes than 1 item should drop both of them.
-    {Q4, _Ack4, [Item1, Item2]} =
-        replayq:pop(Q1, #{count_limit => 10, bytes_limit => {at_least, ItemSize + 1}}),
-    ?assertEqual(0, replayq:bytes(Q4)),
-    ok = replayq:close(Q4),
+    case BytesMode of
+        default ->
+            %% Default behavior: we pop _at most_ N bytes, and return at least 1 item, if any.
+            %% Asking for less bytes than the 2 elements should yield singleton batch.
+            ?assertEqual([Item1], spop(Q1, #{count_limit => 10, bytes_limit => ItemSize - 1}));
+        at_most ->
+            ?assertEqual(
+                [Item1], spop(Q1, #{count_limit => 10, bytes_limit => {at_most, ItemSize - 1}})
+            );
+        at_least ->
+            %% ... but dropping _at least_ less bytes than 1 item should drop both of them.
+            ?assertEqual(
+                [Item1, Item2],
+                spop(Q1, #{count_limit => 10, bytes_limit => {at_least, ItemSize + 1}})
+            )
+    end,
+    ok = replayq:close(Q0),
     ok.
 
 %% helpers ===========================================================
+
+%% simple-pop: pop the queue and return the items
+spop(Q, Opts) ->
+    {_Q1, _AckRef, Items} = replayq:pop(Q, Opts),
+    Items.
 
 cleanup(Dir) ->
     Files = list_segments(Dir),
@@ -672,6 +705,14 @@ filename(Segno) ->
 %% corrupt the segment
 corrupt(#{w_cur := #{fd := Fd}}) ->
     file:write(Fd, "some random bytes").
+
+open(CtConfig, Config0) ->
+    Config =
+        case proplists:get_value(ct_group, CtConfig) of
+            queue -> Config0;
+            ets_exclusive -> Config0#{mem_queue_module => replayq_mem_ets_exclusive}
+        end,
+    replayq:open(Config).
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/test/replayq_proper_SUITE.erl
+++ b/test/replayq_proper_SUITE.erl
@@ -15,13 +15,21 @@
 %%--------------------------------------------------------------------
 
 -module(replayq_proper_SUITE).
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -include_lib("proper/include/proper.hrl").
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
+    [{group, queue}, {group, ets_exclusive}].
+
+groups() ->
+    [
+        {queue, [], all_cases()},
+        {ets_exclusive, [], all_cases()}
+    ].
+
+all_cases() ->
     [
         F
      || {F, _} <- ?MODULE:module_info(exports),
@@ -31,6 +39,12 @@ all() ->
 is_t_function("t_" ++ _) -> true;
 is_t_function(_) -> false.
 
+init_per_group(Group, Config) ->
+    [{ct_group, Group} | Config].
+
+end_per_group(_Group, _Config) ->
+    ok.
+
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(replayq),
     Config.
@@ -38,25 +52,39 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-t_run_persistent(_Config) ->
-    Opts = [{numtests, 1000}, {to_file, user}],
-    true = proper:quickcheck(prop_run(false), Opts).
+get_mem_queue_module(Config) ->
+    case proplists:get_value(ct_group, Config) of
+        queue -> replayq_mem_queue;
+        ets_exclusive -> replayq_mem_ets_exclusive
+    end.
 
-t_run_offload(_Config) ->
+t_run_persistent(Config) ->
+    MemQueueModule = get_mem_queue_module(Config),
     Opts = [{numtests, 1000}, {to_file, user}],
-    true = proper:quickcheck(prop_run(true), Opts).
+    true = proper:quickcheck(prop_run(MemQueueModule, false), Opts).
 
-prop_run(IsOffload) ->
+t_run_offload(Config) ->
+    MemQueueModule = get_mem_queue_module(Config),
+    Opts = [{numtests, 1000}, {to_file, user}],
+    true = proper:quickcheck(prop_run(MemQueueModule, true), Opts).
+
+prop_run(MemQueueModule, IsOffload) ->
     ?FORALL(
         {SegBytes, OpList},
         {prop_seg_bytes(), prop_op_list(IsOffload)},
         begin
             Dir = filename:join([data_dir(), integer_to_list(erlang:system_time())]),
-            MQ = replayq:open(#{mem_only => true}),
-            Cfg = #{dir => Dir, seg_bytes => SegBytes, offload => IsOffload},
-            DQ = replayq:open(Cfg),
+            MQCfg = #{mem_only => true, mem_queue_module => MemQueueModule},
+            MQ = replayq:open(MQCfg),
+            DQCfg = #{
+                dir => Dir,
+                seg_bytes => SegBytes,
+                offload => IsOffload,
+                mem_queue_module => MemQueueModule
+            },
+            DQ = replayq:open(DQCfg),
             try
-                ok = apply_ops(MQ, DQ, OpList, Cfg),
+                ok = apply_ops(MQ, DQ, OpList, MQCfg, DQCfg),
                 true
             after
                 replayq:close(DQ),
@@ -65,16 +93,16 @@ prop_run(IsOffload) ->
         end
     ).
 
-apply_ops(MQ, DQ, [], _) ->
+apply_ops(MQ, DQ, [], _MQCfg, _DQCfg) ->
     ok = compare(MQ, DQ);
-apply_ops(MQ0, DQ0, [Op | Rest], Cfg) ->
-    {MQ, DQ} = apply_op(MQ0, DQ0, Op, Cfg),
+apply_ops(MQ0, DQ0, [Op | Rest], MQCfg, DQCfg) ->
+    {MQ, DQ} = apply_op(MQ0, DQ0, Op, MQCfg, DQCfg),
     ok = compare_stats(MQ, DQ),
-    apply_ops(MQ, DQ, Rest, Cfg).
+    apply_ops(MQ, DQ, Rest, MQCfg, DQCfg).
 
-apply_op(MQ0, DQ0, {append, Items}, _Cfg) ->
+apply_op(MQ0, DQ0, {append, Items}, _MQCfg, _DQCfg) ->
     {replayq:append(MQ0, Items), replayq:append(DQ0, Items)};
-apply_op(MQ0, DQ0, {pop_ack, {Bytes, Count}}, _Cfg) ->
+apply_op(MQ0, DQ0, {pop_ack, {Bytes, Count}}, _MQCfg, _DQCfg) ->
     Opts = #{bytes_limit => Bytes, count_limit => Count},
     {MQ, AckRef1, Items1} = replayq:pop(MQ0, Opts),
     {DQ, AckRef2, Items2} = replayq:pop(DQ0, Opts),
@@ -82,10 +110,13 @@ apply_op(MQ0, DQ0, {pop_ack, {Bytes, Count}}, _Cfg) ->
     ok = replayq:ack_sync(MQ, AckRef1),
     ok = replayq:ack_sync(DQ, AckRef2),
     {MQ, DQ};
-apply_op(MQ, DQ0, reopen, Cfg) ->
-    ok = replayq:close(MQ),
+apply_op(MQ0, DQ0, reopen, MQCfg, DQCfg) ->
+    All = dump(MQ0),
+    ok = replayq:close(MQ0),
+    MQ1 = replayq:open(MQCfg),
+    MQ = replayq:append(MQ1, All),
     ok = replayq:close(DQ0),
-    DQ = replayq:open(Cfg),
+    DQ = replayq:open(DQCfg),
     {MQ, DQ}.
 
 data_dir() -> filename:join(["./test-data", "prop-tests"]).
@@ -129,3 +160,9 @@ compare(Q1, Q2) ->
         true -> compare(NewQ1, NewQ2);
         false -> throw({diff, {Items1, NewQ1}, {Items2, NewQ2}})
     end.
+
+%% dump all items in the queue
+dump(Q) ->
+    Count = replayq:count(Q),
+    {_, _, All} = replayq:pop(Q, #{count_limit => Count + 1}),
+    All.

--- a/test/replayq_proper_SUITE.erl
+++ b/test/replayq_proper_SUITE.erl
@@ -75,16 +75,13 @@ t_run_offload(Config) ->
     true = proper:quickcheck(prop_run(MemQueueModule, true), Opts).
 
 prop_run(MemQueueModule, IsOffload) ->
-    MQOwner = spawn_link(fun() ->
+    F = fun() ->
         receive
             _ -> ok
         end
-    end),
-    DQOwner = spawn_link(fun() ->
-        receive
-            _ -> ok
-        end
-    end),
+    end,
+    MQOwner = spawn_link(F),
+    DQOwner = spawn_link(F),
     ?FORALL(
         {SegBytes, OpList},
         {prop_seg_bytes(), prop_op_list(IsOffload)},


### PR DESCRIPTION
Presumably the `queue` flavor in-memory queue/segment leads to excessive GC pressure.
Introducing ETS flavors in this PR.

Will try to run tests to compare performance when integrated with `wolff`.