### PR TITLE
feat: add api to check if it is currently writing to disk

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+- 0.5.0
+  - Add API to check if it is currently writing to disk.
+
 - 0.4.1
   - Port `replayq:close_and_purge/1` from `dev-0.3.5` to master
 

--- a/src/replayq.erl
+++ b/src/replayq.erl
@@ -18,6 +18,7 @@
 -export([open/1, close/1, close_and_purge/1]).
 -export([append/2, pop/2, ack/2, ack_sync/2, peek/1, overflow/1]).
 -export([count/1, bytes/1, is_empty/1, is_mem_only/1]).
+-export([is_writing_to_disk/1]).
 %% exported for troubleshooting
 -export([do_read_items/2]).
 
@@ -411,6 +412,11 @@ overflow(#{
 is_mem_only(#{config := mem_only}) ->
     true;
 is_mem_only(_) ->
+    false.
+
+is_writing_to_disk(#{w_cur := #{fd := Fd}}) ->
+    Fd =/= ?NO_FD;
+is_writing_to_disk(_) ->
     false.
 
 %% internals =========================================================


### PR DESCRIPTION
This will be useful for callers to decide if batching before enqueue is necessary or not (in order to optimize IOPS).